### PR TITLE
[Config/ws init] ws 초기 세팅, 소켓 테스트 요청 api 구현

### DIFF
--- a/src/main/java/com/run_us/server/domain/test/TestController.java
+++ b/src/main/java/com/run_us/server/domain/test/TestController.java
@@ -1,0 +1,28 @@
+package com.run_us.server.domain.test;
+
+import com.run_us.server.global.common.SuccessResponse;
+import com.run_us.server.global.exceptions.enums.ExampleErrorCode;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Controller;
+
+/**
+ * 테스트용 api 컨트롤러
+ */
+@Controller
+public class TestController {
+    private final SimpMessagingTemplate simpMessagingTemplate;
+
+    public TestController(SimpMessagingTemplate simpMessagingTemplate) {
+        this.simpMessagingTemplate = simpMessagingTemplate;
+    }
+
+    /**
+     * websocket 초기 세팅 테스트용 요청
+     */
+    @MessageMapping("/test/hello")
+    public void initTest() {
+        //TODO : 소켓 응답 코드에 대한 논의 필요. 임시로 EXAMPLE 응답
+        simpMessagingTemplate.convertAndSend("/hello", SuccessResponse.messageOnly(ExampleErrorCode.EXAMPLE));
+    }
+}

--- a/src/main/java/com/run_us/server/domain/test/TestController.java
+++ b/src/main/java/com/run_us/server/domain/test/TestController.java
@@ -25,7 +25,7 @@ public class TestController {
     @MessageMapping("/test/hello")
     public void initTest() {
         //TODO : 소켓 응답 코드에 대한 논의 필요. 임시로 EXAMPLE 응답
-        simpMessagingTemplate.convertAndSend("/hello", SuccessResponse.messageOnly(ExampleErrorCode.EXAMPLE));
         log.info("initTest : /topic/test/hello");
+        simpMessagingTemplate.convertAndSend("/topic/test/hello", SuccessResponse.messageOnly(ExampleErrorCode.EXAMPLE));
     }
 }

--- a/src/main/java/com/run_us/server/domain/test/TestController.java
+++ b/src/main/java/com/run_us/server/domain/test/TestController.java
@@ -2,6 +2,7 @@ package com.run_us.server.domain.test;
 
 import com.run_us.server.global.common.SuccessResponse;
 import com.run_us.server.global.exceptions.enums.ExampleErrorCode;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Controller;
@@ -9,6 +10,7 @@ import org.springframework.stereotype.Controller;
 /**
  * 테스트용 api 컨트롤러
  */
+@Slf4j
 @Controller
 public class TestController {
     private final SimpMessagingTemplate simpMessagingTemplate;
@@ -24,5 +26,6 @@ public class TestController {
     public void initTest() {
         //TODO : 소켓 응답 코드에 대한 논의 필요. 임시로 EXAMPLE 응답
         simpMessagingTemplate.convertAndSend("/hello", SuccessResponse.messageOnly(ExampleErrorCode.EXAMPLE));
+        log.info("initTest : /topic/test/hello");
     }
 }

--- a/src/main/java/com/run_us/server/global/common/SuccessResponse.java
+++ b/src/main/java/com/run_us/server/global/common/SuccessResponse.java
@@ -1,7 +1,9 @@
 package com.run_us.server.global.common;
 
 import com.run_us.server.global.exceptions.enums.CustomResponseCode;
+import lombok.Getter;
 
+@Getter
 public class SuccessResponse extends Response {
 
   private final Object payload;

--- a/src/main/java/com/run_us/server/global/config/WebSocketConfig.java
+++ b/src/main/java/com/run_us/server/global/config/WebSocketConfig.java
@@ -1,0 +1,23 @@
+package com.run_us.server.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws-hello").setAllowedOriginPatterns("*"); // ws 연결 요청 - 모든 곳으로부터의 요청 허용
+    }
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        registry.enableSimpleBroker("/topic"); // 구독, 전송(sub)
+        registry.setApplicationDestinationPrefixes("/app"); // 발행(pub)
+    }
+}

--- a/src/main/java/com/run_us/server/global/config/WebSocketConfig.java
+++ b/src/main/java/com/run_us/server/global/config/WebSocketConfig.java
@@ -6,6 +6,9 @@ import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBr
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
 
+/**
+ * websocket config 클래스
+ */
 @Configuration
 @EnableWebSocketMessageBroker
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {


### PR DESCRIPTION
### 연관된 이슈를 적어주세요 📌
x

### 작업한 내용을 설명해주세요 ✔️
- src/main/java/com/run_us/server/global/config/WebSocketConfig.java : ws 초기 세팅
- src/main/java/com/run_us/server/domain/test/TestController.java : 테스트용 컨트롤러. 소켓 테스트 요청 api 구현


- 테스트 요청 (포스트맨 init test 요청 참고)
  1. ws://localhost:8080/ws-hello : 소켓 연결 url (핸드셰이킹)
  2. topic/test/hello : 해당 경로 구독
  3. app/test/hello : 전송 테스트용 api


![image](https://github.com/user-attachments/assets/2c828c81-5dbc-49a5-98f7-496e560a47dc)


### 트러블 슈팅
- converter 관련 에러 -> SuccessResponse 클래스에 Getter 추가
- 포스트맨 STOMP 테스트 고난
  - 마지막에 빈줄 엔터와 NULL문자로 마무리할 것
  - url Connect 버튼으로 연결한 후, CONNECT 요청도 전송해줘야 함 
  (Connect 버튼 -> CONNECT -> SUBSCRIBE, SEND .... )
  -> document 잘 참고하기 . . .

### 리뷰어에게 하고 싶은 말을 적어주세요
- 정해야 할 것
  - 소켓 응답 상태코드 어떻게 줄 지?
  - git commit 메세지 태그 중 log가 없어서 그냥 chore로 넣는데 괜찮은지?
  - 새 기능 완성 아니고 config 코드나 코드 조금 더한것도 다 feat로 태그 달아야 하는데 괜찮은지? (add 태그 안써도 괜찮을지)


감사합니다~

### 확인하기

- [ ] : 코드에 에러가 없는지 확인했나요?
- [ ] : PR에 설명을 기재했나요?
- [ ] : PR 태그를 붙였나요?
- [ ] : 불필요한 로그나 `System.out`을 제거했나요?