### PR TITLE
Feature/user entity

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
-
+	implementation 'io.hypersistence:hypersistence-utils-hibernate-63:3.8.2'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.h2database:h2'

--- a/src/main/java/com/run_us/server/domain/user/model/Gender.java
+++ b/src/main/java/com/run_us/server/domain/user/model/Gender.java
@@ -1,0 +1,7 @@
+package com.run_us.server.domain.user.model;
+
+public enum Gender {
+  FEMALE,
+  MALE,
+  NONE
+}

--- a/src/main/java/com/run_us/server/domain/user/model/Gender.java
+++ b/src/main/java/com/run_us/server/domain/user/model/Gender.java
@@ -3,5 +3,6 @@ package com.run_us.server.domain.user.model;
 public enum Gender {
   FEMALE,
   MALE,
+  OTHER,
   NONE
 }

--- a/src/main/java/com/run_us/server/domain/user/model/OAuthInfo.java
+++ b/src/main/java/com/run_us/server/domain/user/model/OAuthInfo.java
@@ -1,6 +1,7 @@
 package com.run_us.server.domain.user.model;
 
 import com.run_us.server.global.common.DateAudit;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -8,32 +9,44 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.validation.annotation.Validated;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class OAuthInfo extends DateAudit {
-
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
   @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id", nullable = false)
   private User user;
 
   @Enumerated(EnumType.STRING)
+  @Column(name = "provider", nullable = false)
   private SocialProvider provider;
 
+  @Column(name = "provider_user_id", nullable = false)
   private String providerId;
 
+  /***
+   * OAuthInfo Constructor
+   * @param user OAuth연동할 유저 엔티티
+   * @param provider 소셜 로그인 제공자
+   * @param providerId 소셜 로그인 이메일 / guid
+   */
   @Builder
-  public OAuthInfo(@Validated User user, SocialProvider provider, String providerId) {
+  public OAuthInfo(
+      @NotNull User user,
+      @NotNull SocialProvider provider,
+      @NotNull String providerId) {
     this.user = user;
     this.provider = provider;
     this.providerId = providerId;

--- a/src/main/java/com/run_us/server/domain/user/model/OAuthInfo.java
+++ b/src/main/java/com/run_us/server/domain/user/model/OAuthInfo.java
@@ -1,0 +1,41 @@
+package com.run_us.server.domain.user.model;
+
+import com.run_us.server.global.common.DateAudit;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OAuthInfo extends DateAudit {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  private User user;
+
+  @Enumerated(EnumType.STRING)
+  private SocialProvider provider;
+
+  private String providerId;
+
+  @Builder
+  public OAuthInfo(@Validated User user, SocialProvider provider, String providerId) {
+    this.user = user;
+    this.provider = provider;
+    this.providerId = providerId;
+  }
+}

--- a/src/main/java/com/run_us/server/domain/user/model/Penalty.java
+++ b/src/main/java/com/run_us/server/domain/user/model/Penalty.java
@@ -1,0 +1,64 @@
+package com.run_us.server.domain.user.model;
+
+import static com.run_us.server.global.common.GlobalConsts.TIME_ZONE_ID;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "user_penalties")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Penalty {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id", nullable = false)
+  private User user;
+
+  @Column(name = "desc")
+  private String description;
+
+  @Column(name = "penalty_type", nullable = false)
+  private String penaltyType;
+
+  @Column(name = "applied_at", nullable = false)
+  private ZonedDateTime appliedAt;
+
+  @Column(name = "expires_at", nullable = false)
+  private ZonedDateTime expiresAt;
+
+  @Builder
+  public Penalty(String description, @NotNull String penaltyType, @NotNull ZonedDateTime expiresAt) {
+    this.description = description;
+    this.penaltyType = penaltyType;
+    this.expiresAt = expiresAt;
+  }
+
+  @PrePersist
+  public void onPersist() {
+    this.appliedAt = ZonedDateTime.now(ZoneId.of(TIME_ZONE_ID));
+  }
+
+  public void applyPenaltyToUser(User user) {
+    this.user = user;
+  }
+}

--- a/src/main/java/com/run_us/server/domain/user/model/SocialProvider.java
+++ b/src/main/java/com/run_us/server/domain/user/model/SocialProvider.java
@@ -1,0 +1,2 @@
+package com.run_us.server.domain.user.model;public enum SocialProvider {
+}

--- a/src/main/java/com/run_us/server/domain/user/model/SocialProvider.java
+++ b/src/main/java/com/run_us/server/domain/user/model/SocialProvider.java
@@ -1,2 +1,5 @@
-package com.run_us.server.domain.user.model;public enum SocialProvider {
+package com.run_us.server.domain.user.model;
+
+public enum SocialProvider {
+  KAKAO
 }

--- a/src/main/java/com/run_us/server/domain/user/model/User.java
+++ b/src/main/java/com/run_us/server/domain/user/model/User.java
@@ -1,0 +1,119 @@
+package com.run_us.server.domain.user.model;
+
+import static com.run_us.server.global.common.GlobalConsts.DEFAULT_IMG_URL;
+
+import com.run_us.server.global.common.DateAudit;
+import io.hypersistence.tsid.TSID;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.SQLRestriction;
+
+@Entity
+@Table(name = "users")
+@Getter
+@NoArgsConstructor
+@SQLRestriction("deleted_at is null")
+public class User extends DateAudit{
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "user_id")
+  private Long id;
+
+  @Column(name = "public_id", nullable = false)
+  private String publicId;
+
+  @Column(name = "nickname", nullable = false)
+  private String nickname;
+
+  @Column(name = "birth_date")
+  private LocalDate birthDate;
+
+  @Column(name = "gender")
+  @Enumerated(EnumType.STRING)
+  @ColumnDefault("'NONE'")
+  private Gender gender;
+
+  @Column(name = "img_url")
+  private String imgUrl = DEFAULT_IMG_URL;
+
+  @Column(name = "deleted_at")
+  private LocalDateTime deletedAt;
+
+  // 생성 관련 메소드
+
+  /**
+   * User Constructor
+   *
+   * @param nickname 사용자 닉네임, 중복가능, Not null
+   * @param birthDate 사용자 생년월일
+   * */
+  @Builder
+  public User(@NotNull String nickname, LocalDate birthDate) {
+    this.nickname = nickname;
+    this.birthDate = birthDate;
+  }
+
+  /***
+   *
+   * @param nickname 사용자 닉네임, 중복가능, Not null
+   * @param birthDate 사용자 생년월일
+   * @param gender 사용자 성별, default NONE
+   * @param imgUrl 사용자 프로필 이미지 URL, default DEFAULT_IMG_URL
+   */
+  @Builder
+  public User(@NotNull String nickname, LocalDate birthDate, Gender gender, String imgUrl) {
+    this.nickname = nickname;
+    this.birthDate = birthDate;
+    this.gender = gender;
+    this.imgUrl = imgUrl;
+  }
+
+  @Override
+  protected void prePersist() {
+    super.prePersist();
+    this.publicId = TSID.Factory.getTsid().toString();
+  }
+
+  // 비즈니스 로직 메소드
+
+  /**
+   * change profile image url method
+   *
+   * @param newImgUrl 변경할 이미지 URL
+   * */
+  public void changeProfileImgUrl(@NotNull String newImgUrl) {
+    if(newImgUrl.isEmpty()) {
+      this.imgUrl = DEFAULT_IMG_URL;
+      return;
+    }
+    this.imgUrl = newImgUrl;
+  }
+
+  /***
+   * soft delete method. deletedAt에 현재 시간을 저장
+   */
+  public void remove() {
+    if(isRemoved()) {
+      throw new IllegalStateException();
+    }
+    this.deletedAt = LocalDateTime.now();
+  }
+
+  private boolean isRemoved() {
+    return deletedAt != null;
+  }
+}

--- a/src/main/java/com/run_us/server/domain/user/model/User.java
+++ b/src/main/java/com/run_us/server/domain/user/model/User.java
@@ -48,7 +48,7 @@ public class User extends DateAudit{
   private Gender gender;
 
   @Column(name = "img_url")
-  private String imgUrl = DEFAULT_IMG_URL;
+  private String imgUrl;
 
   @Column(name = "deleted_at")
   private LocalDateTime deletedAt;
@@ -72,7 +72,7 @@ public class User extends DateAudit{
    * @param nickname 사용자 닉네임, 중복가능, Not null
    * @param birthDate 사용자 생년월일
    * @param gender 사용자 성별, default NONE
-   * @param imgUrl 사용자 프로필 이미지 URL, default DEFAULT_IMG_URL
+   * @param imgUrl 사용자 프로필 이미지 URL
    */
   @Builder
   public User(@NotNull String nickname, LocalDate birthDate, Gender gender, String imgUrl) {
@@ -96,10 +96,6 @@ public class User extends DateAudit{
    * @param newImgUrl 변경할 이미지 URL
    * */
   public void changeProfileImgUrl(@NotNull String newImgUrl) {
-    if(newImgUrl.isEmpty()) {
-      this.imgUrl = DEFAULT_IMG_URL;
-      return;
-    }
     this.imgUrl = newImgUrl;
   }
 

--- a/src/main/java/com/run_us/server/domain/user/repository/OAuthInfoRepository.java
+++ b/src/main/java/com/run_us/server/domain/user/repository/OAuthInfoRepository.java
@@ -1,0 +1,10 @@
+package com.run_us.server.domain.user.repository;
+
+import com.run_us.server.domain.user.model.OAuthInfo;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface OAuthInfoRepository extends JpaRepository<OAuthInfo, Long> {
+
+}

--- a/src/main/java/com/run_us/server/domain/user/repository/PenaltyRepository.java
+++ b/src/main/java/com/run_us/server/domain/user/repository/PenaltyRepository.java
@@ -1,0 +1,14 @@
+package com.run_us.server.domain.user.repository;
+
+import com.run_us.server.domain.user.model.Penalty;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PenaltyRepository extends JpaRepository<Penalty, Long> {
+
+  @Query("SELECT p FROM Penalty p WHERE p.user.id = :userId")
+  List<Penalty> findByUserId(Long userId);
+}

--- a/src/main/java/com/run_us/server/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/run_us/server/domain/user/repository/UserRepository.java
@@ -1,0 +1,12 @@
+package com.run_us.server.domain.user.repository;
+
+import com.run_us.server.domain.user.model.User;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long>{
+
+  Optional<User> findByNickname(String nickname);
+}

--- a/src/main/java/com/run_us/server/global/common/DateAudit.java
+++ b/src/main/java/com/run_us/server/global/common/DateAudit.java
@@ -19,13 +19,13 @@ public abstract class DateAudit implements Serializable {
   protected ZonedDateTime updatedAt;
 
   @PrePersist
-  public void prePersist() {
+  protected void prePersist() {
     this.createdAt = ZonedDateTime.now(ZoneId.of(TIME_ZONE_ID));
     this.updatedAt = ZonedDateTime.now(ZoneId.of(TIME_ZONE_ID));
   }
 
   @PreUpdate
-  public void preUpdate() {
+  protected void preUpdate() {
     this.updatedAt = ZonedDateTime.now(ZoneId.of(TIME_ZONE_ID));
   }
 }

--- a/src/main/java/com/run_us/server/global/common/GlobalConsts.java
+++ b/src/main/java/com/run_us/server/global/common/GlobalConsts.java
@@ -2,4 +2,5 @@ package com.run_us.server.global.common;
 
 public final class GlobalConsts {
   public static final String TIME_ZONE_ID = "Asia/Seoul";
+  public static final String DEFAULT_IMG_URL = "default_img_url";
 }

--- a/src/test/java/com/run_us/server/domain/user/model/PenaltyRepositoryTest.java
+++ b/src/test/java/com/run_us/server/domain/user/model/PenaltyRepositoryTest.java
@@ -1,0 +1,52 @@
+package com.run_us.server.domain.user.model;
+
+import static com.run_us.server.global.common.GlobalConsts.TIME_ZONE_ID;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import com.run_us.server.domain.user.repository.PenaltyRepository;
+import com.run_us.server.domain.user.repository.UserRepository;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@DataJpaTest
+class PenaltyRepositoryTest {
+
+  @Autowired
+  private PenaltyRepository penaltyRepository;
+
+  @Autowired
+  private UserRepository userRepository;
+
+  @Transactional
+  @Test
+  void create_penalty() {
+    //given
+    User user = new User("nickname", LocalDate.now());
+    userRepository.saveAndFlush(user);
+
+
+    Penalty penalty = Penalty.builder()
+        .penaltyType("PERMANENT_BAN")
+        .description("banned")
+        .expiresAt(ZonedDateTime.of(LocalDateTime.now(), ZoneId.of(TIME_ZONE_ID)))
+        .build();
+    //when
+    User savedUser = userRepository.findByNickname("nickname").get();
+    penalty.applyPenaltyToUser(savedUser);
+    penaltyRepository.save(penalty);
+
+    List<Penalty> createdPenalty = penaltyRepository.findByUserId(savedUser.getId());
+
+    //then
+    assertFalse(createdPenalty.isEmpty());
+    assertEquals(penalty, createdPenalty.get(0));
+  }
+}

--- a/src/test/java/com/run_us/server/domain/user/model/UserRepositoryTest.java
+++ b/src/test/java/com/run_us/server/domain/user/model/UserRepositoryTest.java
@@ -1,0 +1,52 @@
+package com.run_us.server.domain.user.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.run_us.server.domain.user.repository.UserRepository;
+import java.time.LocalDate;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@DataJpaTest
+class UserRepositoryTest {
+
+  @Autowired
+  private UserRepository userRepository;
+
+  @Transactional
+  @Test
+  void create_user() {
+    //given
+    User user = new User("nickname", LocalDate.now());
+
+    //when
+    userRepository.save(user);
+    Optional<User> createdUser = userRepository.findByNickname("nickname");
+
+    //then
+    assertEquals(user, createdUser.get());
+    assertNotNull(createdUser.get().getPublicId());
+  }
+
+  @Transactional
+  @Test
+  void remove_user() {
+    //given
+    User user = new User("nickname", LocalDate.now());
+    userRepository.save(user);
+
+    //when
+    user.remove();
+    Optional<User> savedUser = userRepository.findByNickname("nickname");
+
+    //then
+    assertNotNull(user.getDeletedAt());
+    assertTrue(savedUser.isEmpty());
+  }
+
+}

--- a/src/test/java/com/run_us/server/domain/user/model/UserTest.java
+++ b/src/test/java/com/run_us/server/domain/user/model/UserTest.java
@@ -1,0 +1,63 @@
+package com.run_us.server.domain.user.model;
+
+import static com.run_us.server.global.common.GlobalConsts.DEFAULT_IMG_URL;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.LocalDate;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class UserTest {
+
+  private static final String URL_FIXTURE = "img_URL";
+
+  User getUserFixture() {
+   return new User("nickname", LocalDate.of(2000, 4, 21));
+  }
+
+  private static Stream<Arguments> provideChangeUserProfileImgUrl() {
+    return Stream.of(
+        Arguments.of(URL_FIXTURE, URL_FIXTURE),
+        Arguments.of("", DEFAULT_IMG_URL)
+    );
+  }
+
+  @Test
+  @DisplayName("User 객체 생성 테스트")
+  void create_user() {
+    User user = new User("nickname", LocalDate.of(2000, 4, 21));
+    assertEquals(user.getNickname(), "nickname");
+    assertEquals(user.getBirthDate(), LocalDate.of(2000, 4, 21));
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideChangeUserProfileImgUrl")
+  @DisplayName("User 프로필 이미지 변경")
+  void change_user_profile_img_url(String newImgUrl, String expectedImgUrl) {
+    //given
+    User user = getUserFixture();
+
+    //when
+    user.changeProfileImgUrl(newImgUrl);
+
+    //then
+    assertEquals(user.getImgUrl(), expectedImgUrl);
+  }
+
+  @Test
+  @DisplayName("User soft delete")
+  void remove_user() {
+    //given
+    User user = getUserFixture();
+
+    //when
+    user.remove();
+
+    //then
+    assertNotNull(user.getDeletedAt());
+  }
+}

--- a/src/test/java/com/run_us/server/domain/user/model/UserTest.java
+++ b/src/test/java/com/run_us/server/domain/user/model/UserTest.java
@@ -1,14 +1,10 @@
 package com.run_us.server.domain.user.model;
 
-import static com.run_us.server.global.common.GlobalConsts.DEFAULT_IMG_URL;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.time.LocalDate;
-import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 class UserTest {
@@ -19,13 +15,6 @@ class UserTest {
    return new User("nickname", LocalDate.of(2000, 4, 21));
   }
 
-  private static Stream<Arguments> provideChangeUserProfileImgUrl() {
-    return Stream.of(
-        Arguments.of(URL_FIXTURE, URL_FIXTURE),
-        Arguments.of("", DEFAULT_IMG_URL)
-    );
-  }
-
   @Test
   @DisplayName("User 객체 생성 테스트")
   void create_user() {
@@ -34,15 +23,14 @@ class UserTest {
     assertEquals(user.getBirthDate(), LocalDate.of(2000, 4, 21));
   }
 
-  @ParameterizedTest
   @MethodSource("provideChangeUserProfileImgUrl")
   @DisplayName("User 프로필 이미지 변경")
-  void change_user_profile_img_url(String newImgUrl, String expectedImgUrl) {
+  void change_user_profile_img_url() {
     //given
     User user = getUserFixture();
-
+    String expectedImgUrl = URL_FIXTURE;
     //when
-    user.changeProfileImgUrl(newImgUrl);
+    user.changeProfileImgUrl(expectedImgUrl);
 
     //then
     assertEquals(user.getImgUrl(), expectedImgUrl);


### PR DESCRIPTION
### 연관된 이슈를 적어주세요 📌
- NULL 체크
  - 간단한 타입체크는 Bean validation을 사용하기로 했어요
 #5 
 
### 작업한 내용을 설명해주세요 ✔️
- 유저 JPA 엔티티 코드 작성
- 테스트 코드 작성

### 트러블 슈팅
- TSID를 어노테이션으로 적용하려면 `@Id` 가 필요한데 PK는 아니라서 팩토리 메서드를 썼어요.
`DateAudit` 클래스를 상속받아서 사용하기에 `@PrePersist`가 적용된 메서드를 오버라이딩 해서 사용했습니다.

```
@Override
  protected void prePersist() {
    super.prePersist();
    this.publicId = TSID.Factory.getTsid().toString();
  }
```


### 리뷰어에게 하고 싶은 말을 적어주세요
#### 앞으로 디코에서 논의하면 깃허브 이슈를 생성하는게 어떨까요? PR에서 반영하기 어렵네요..(자동화안돼나..)

**중요**

> 유저 프로필을 테이블을 분리해서 사용하기로 했었는데 JPA연관관계를 매핑하다가 저의 실력부족으로 이걸 어떻게 할지 고민이 되더군요.
> - VO라고 하기에는 수정이 너무 잦다 .
> -  FK의 위치가 애매하다 1 : 1관계에서 사용 방식에 따라 N+1이 발생할 수 있음.
> [https://skatpdnjs.tistory.com/95](url)



#### **그래서 우선 단일 테이블로 작성했습니다.**
- immutable에 가까운 부분만 VO로 만들고 컨텐츠, 러닝관련정보는 테이블로 빼는게 어떨까요?
### 확인하기

- [x] : 코드에 에러가 없는지 확인했나요?
- [x] : PR에 설명을 기재했나요?
- [x] : PR 태그를 붙였나요?
- [x] : 불필요한 로그나 `System.out`을 제거했나요?