### PR TITLE
[Bug] user entity builder

### DIFF
--- a/src/main/java/com/run_us/server/domain/user/model/User.java
+++ b/src/main/java/com/run_us/server/domain/user/model/User.java
@@ -1,7 +1,5 @@
 package com.run_us.server.domain.user.model;
 
-import static com.run_us.server.global.common.GlobalConsts.DEFAULT_IMG_URL;
-
 import com.run_us.server.global.common.DateAudit;
 import io.hypersistence.tsid.TSID;
 import jakarta.persistence.Column;
@@ -55,20 +53,8 @@ public class User extends DateAudit{
 
   // 생성 관련 메소드
 
-  /**
-   * User Constructor
-   *
-   * @param nickname 사용자 닉네임, 중복가능, Not null
-   * @param birthDate 사용자 생년월일
-   * */
-  @Builder
-  public User(@NotNull String nickname, LocalDate birthDate) {
-    this.nickname = nickname;
-    this.birthDate = birthDate;
-  }
-
   /***
-   *
+   * User 생성자
    * @param nickname 사용자 닉네임, 중복가능, Not null
    * @param birthDate 사용자 생년월일
    * @param gender 사용자 성별, default NONE

--- a/src/test/java/com/run_us/server/domain/user/model/PenaltyRepositoryTest.java
+++ b/src/test/java/com/run_us/server/domain/user/model/PenaltyRepositoryTest.java
@@ -29,7 +29,7 @@ class PenaltyRepositoryTest {
   @Test
   void create_penalty() {
     //given
-    User user = new User("nickname", LocalDate.now());
+    User user = UserFixtures.getDefaultUser();
     userRepository.saveAndFlush(user);
 
 

--- a/src/test/java/com/run_us/server/domain/user/model/UserFixtures.java
+++ b/src/test/java/com/run_us/server/domain/user/model/UserFixtures.java
@@ -1,0 +1,24 @@
+package com.run_us.server.domain.user.model;
+
+import java.time.LocalDate;
+
+public final class UserFixtures {
+
+  public static final LocalDate DEFAULT_BIRTH_DATE = LocalDate.of(1999, 1, 1);
+
+  public static User getDefaultUser() {
+    return User.builder()
+        .nickname("NICKNAME")
+        .birthDate(DEFAULT_BIRTH_DATE)
+        .gender(Gender.NONE)
+        .build();
+  }
+
+  public static User getDefaultUserWithNickname(String nickname) {
+    return User.builder()
+        .nickname(nickname)
+        .birthDate(DEFAULT_BIRTH_DATE)
+        .gender(Gender.NONE)
+        .build();
+  }
+}

--- a/src/test/java/com/run_us/server/domain/user/model/UserRepositoryTest.java
+++ b/src/test/java/com/run_us/server/domain/user/model/UserRepositoryTest.java
@@ -22,7 +22,7 @@ class UserRepositoryTest {
   @Test
   void create_user() {
     //given
-    User user = new User("nickname", LocalDate.now());
+    User user = UserFixtures.getDefaultUser();
 
     //when
     userRepository.save(user);
@@ -37,7 +37,7 @@ class UserRepositoryTest {
   @Test
   void remove_user() {
     //given
-    User user = new User("nickname", LocalDate.now());
+    User user = UserFixtures.getDefaultUser();
     userRepository.save(user);
 
     //when

--- a/src/test/java/com/run_us/server/domain/user/model/UserTest.java
+++ b/src/test/java/com/run_us/server/domain/user/model/UserTest.java
@@ -11,23 +11,20 @@ class UserTest {
 
   private static final String URL_FIXTURE = "img_URL";
 
-  User getUserFixture() {
-   return new User("nickname", LocalDate.of(2000, 4, 21));
-  }
 
   @Test
   @DisplayName("User 객체 생성 테스트")
   void create_user() {
-    User user = new User("nickname", LocalDate.of(2000, 4, 21));
+    User user = UserFixtures.getDefaultUserWithNickname("nickname");
     assertEquals(user.getNickname(), "nickname");
-    assertEquals(user.getBirthDate(), LocalDate.of(2000, 4, 21));
+    assertEquals(user.getBirthDate(), UserFixtures.DEFAULT_BIRTH_DATE);
   }
 
   @MethodSource("provideChangeUserProfileImgUrl")
   @DisplayName("User 프로필 이미지 변경")
   void change_user_profile_img_url() {
     //given
-    User user = getUserFixture();
+    User user = UserFixtures.getDefaultUser();
     String expectedImgUrl = URL_FIXTURE;
     //when
     user.changeProfileImgUrl(expectedImgUrl);
@@ -40,7 +37,7 @@ class UserTest {
   @DisplayName("User soft delete")
   void remove_user() {
     //given
-    User user = getUserFixture();
+    User user = UserFixtures.getDefaultUser();
 
     //when
     user.remove();


### PR DESCRIPTION
### 연관된 이슈를 적어주세요 📌
#7 

### 작업한 내용을 설명해주세요 ✔️

- 빌더가 여러개 선언되어있을 때 생성되는 클래스명이 동일하여 하나가 적용이 안됨.
![Screenshot 2024-09-14 at 11 46 07 PM](https://github.com/user-attachments/assets/66113e17-10fd-437f-88da-5e0789abce50)

- 위와 같이 빌더 어노테이션에 이름을 바꾸도록 선언할 수 있으나, **불필요한 생성자의 문제**로 파악하여 생성자를 삭제하는 방향으로 수정.

### 트러블 슈팅

### 리뷰어에게 하고 싶은 말을 적어주세요

### 확인하기

- [x] : 코드에 에러가 없는지 확인했나요?
- [x] : PR에 설명을 기재했나요?
- [x] : PR 태그를 붙였나요?
- [x] : 불필요한 로그나 `System.out`을 제거했나요?