### PR TITLE
[Feature/add embedded redis] 테스트환경을 위한 Embedded Redis 설정

### DIFF
--- a/.github/workflows/develop-ci.yml
+++ b/.github/workflows/develop-ci.yml
@@ -29,6 +29,9 @@ jobs:
         run: |
           touch ./src/main/resources/application.yml
           echo "${{ secrets.APPLICATION_DEV }}" > ./src/main/resources/application.yml
+          mkdir -p ./src/test/resources
+          touch ./src/test/resources/application-test.yml
+          echo "${{ secrets.APPLICATION_TEST }}" > ./src/test/resources/application-test.yml
         shell: bash
 
       - name: Build and analyze

--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,7 @@ dependencies {
 
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'com.github.codemonstur:embedded-redis:1.4.2'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/src/main/java/com/run_us/server/global/config/RedisConfig.java
+++ b/src/main/java/com/run_us/server/global/config/RedisConfig.java
@@ -3,19 +3,23 @@ package com.run_us.server.global.config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
+@EnableRedisRepositories
+@Profile({"local", "dev"})
 public class RedisConfig {
 
-    @Value("${spring.redis.host}")
+    @Value("${spring.data.redis.host}")
     private String redisHost;
 
-    @Value("${spring.redis.port}")
+    @Value("${spring.data.redis.port}")
     private int redisPort;
 
     @Bean

--- a/src/test/java/com/run_us/server/config/EmbeddedRedisConfiguration.java
+++ b/src/test/java/com/run_us/server/config/EmbeddedRedisConfiguration.java
@@ -1,0 +1,71 @@
+package com.run_us.server.config;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import org.junit.jupiter.api.DisplayName;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.util.StringUtils;
+import redis.embedded.RedisServer;
+
+@DisplayName("Test Redis Configuration")
+@Profile("test")
+@TestConfiguration
+public class EmbeddedRedisConfiguration {
+
+  private final RedisServer redisServer;
+  private final int redisPort;
+
+  public EmbeddedRedisConfiguration() throws IOException {
+    this.redisPort = findAvailablePort();
+    this.redisServer = new RedisServer(redisPort);
+  }
+
+  private int findAvailablePort() throws IOException {
+    for (int port = 10000; port <= 65535; port++) {
+      Process process = executeGrepProcessCommand(port);
+      if (!isRunning(process)) {
+        return port;
+      }
+    }
+    throw new IllegalArgumentException("Not Found Available port: 10000 ~ 65535");
+  }
+
+  private Process executeGrepProcessCommand(int port) throws IOException {
+    String command = String.format("netstat -nat | grep LISTEN|grep %d", port);
+    String[] shell = {"/bin/sh", "-c", command};
+    return Runtime.getRuntime().exec(shell);
+  }
+
+  private boolean isRunning(Process process) {
+    String line;
+    StringBuilder pidInfo = new StringBuilder();
+
+    try (BufferedReader input = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+      while ((line = input.readLine()) != null) {
+        pidInfo.append(line);
+      }
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+    return StringUtils.hasText(pidInfo.toString());
+  }
+
+  @PostConstruct
+  public void postConstruct() throws IOException {
+    redisServer.start();
+  }
+
+  @PreDestroy
+  public void preDestroy() throws IOException {
+    redisServer.stop();
+  }
+
+  public int getRedisPort() {
+    return redisPort;
+  }
+
+}

--- a/src/test/java/com/run_us/server/config/TestRedisConfiguration.java
+++ b/src/test/java/com/run_us/server/config/TestRedisConfiguration.java
@@ -1,0 +1,49 @@
+package com.run_us.server.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@TestConfiguration
+@Profile("test")
+@EnableRedisRepositories
+@Import(EmbeddedRedisConfiguration.class)
+public class TestRedisConfiguration {
+
+  private final EmbeddedRedisConfiguration testRedisConfiguration;
+
+  @Value("${spring.data.redis.host}")
+  private String redisHost;
+
+  private final int redisPort;
+
+  public TestRedisConfiguration(EmbeddedRedisConfiguration testRedisConfiguration) {
+    this.testRedisConfiguration = testRedisConfiguration;
+    this.redisPort = testRedisConfiguration.getRedisPort();
+  }
+
+  @Bean
+  public RedisConnectionFactory redisConnectionFactory() {
+    RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration();
+    redisStandaloneConfiguration.setHostName(redisHost);
+    redisStandaloneConfiguration.setPort(redisPort);
+    return new LettuceConnectionFactory(redisStandaloneConfiguration);
+  }
+
+  @Bean
+  public RedisTemplate<String, String> redisTemplate() {
+    RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+    redisTemplate.setConnectionFactory(redisConnectionFactory());
+    redisTemplate.setKeySerializer(new StringRedisSerializer());
+    redisTemplate.setValueSerializer(new StringRedisSerializer());
+    return redisTemplate;
+  }
+}

--- a/src/test/java/com/run_us/server/domain/running/RunningRedisRepositoryTest.java
+++ b/src/test/java/com/run_us/server/domain/running/RunningRedisRepositoryTest.java
@@ -1,0 +1,53 @@
+package com.run_us.server.domain.running;
+
+import com.run_us.server.config.TestRedisConfiguration;
+import com.run_us.server.domain.running.model.ParticipantStatus;
+import com.run_us.server.domain.running.repository.RunningRedisRepository;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest()
+@Import(TestRedisConfiguration.class)
+@ActiveProfiles("test")
+@DisplayName("RunningRedisRepository 테스트의")
+class RunningRedisRepositoryTest {
+
+  @Autowired
+  RunningRedisRepository runningRedisRepository;
+
+  @Autowired
+  RedisTemplate<String, String> redisTemplate;
+
+  @Nested
+  @DisplayName("updateParticipantStatus 메소드는")
+  class Describe_updateParticipantStatus {
+
+    @Nested
+    @DisplayName("참가자의 상태를 READY로 변경했을 때")
+    class Context_with_a_participant {
+
+      @DisplayName("참가자의 상태를 READY변경한다")
+      @Test
+      void it_updates_participant_status() {
+        // given
+        String key = "1";
+        String value = "1";
+        // when
+        runningRedisRepository.updateParticipantStatus(key, value, ParticipantStatus.READY);
+
+        // then
+        String result = redisTemplate.opsForValue().get("running:1:1:status");
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals("READY", result);
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
### 연관된 이슈를 적어주세요 📌
x

### 작업한 내용을 설명해주세요 ✔️

- 테스트 환경에서 사용할 Embedded-redis 의존성 추가, 환경 설정
- CI 워크플로우에 application-test.yml 주입 추가
- 레디스 연결 테스트를 위한 `updatePariticpantStatus` 함수의 테스트 코드 작성
- Embedded-Redis를 위한 설정파일과 기존 레디스 환경 설정 분리를 위한 프로필 추가

### 트러블 슈팅
- 레디스 ConnectionFactory에서 `io.lettuce.core.RedisCommandExecutionException: NOAUTH Authentication required` 에러가 발생.

제 맥북에는 레디스에 비밀번호가 걸려있어서 환경설정을 안해주니 에러가 생기더라구요. 테스트 환경에서는 개인 환경에 구애받지않고 동작해야하기에 EmbeddedRedis를 추가했습니다.

### 리뷰어에게 하고 싶은 말을 적어주세요
- Spring Profile은
local / dev / test / prod 4가지 어떨까요?

### 확인하기

- [x] : 코드에 에러가 없는지 확인했나요?
- [x] : PR에 설명을 기재했나요?
- [x] : PR 태그를 붙였나요?
- [x] : 불필요한 로그나 `System.out`을 제거했나요?