### PR TITLE
Feature/fetch joined user

### DIFF
--- a/src/main/java/com/run_us/server/domains/running/controller/JoinedParticipantsDto.java
+++ b/src/main/java/com/run_us/server/domains/running/controller/JoinedParticipantsDto.java
@@ -1,0 +1,20 @@
+package com.run_us.server.domains.running.controller;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class JoinedParticipantsDto {
+
+  private String name;
+  private String imgUrl;
+
+  @Builder
+  public JoinedParticipantsDto(String name, String imgUrl) {
+    this.name = name;
+    this.imgUrl = imgUrl;
+  }
+}

--- a/src/main/java/com/run_us/server/domains/running/controller/RunningController.java
+++ b/src/main/java/com/run_us/server/domains/running/controller/RunningController.java
@@ -4,14 +4,17 @@ import com.run_us.server.domains.running.controller.model.request.RunningCreateR
 import com.run_us.server.domains.running.service.RunningPreparationService;
 import com.run_us.server.global.common.SuccessResponse;
 import com.run_us.server.global.exceptions.enums.ExampleErrorCode;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/running")
+@RequestMapping("/runnings")
 @RequiredArgsConstructor
 public class RunningController {
 
@@ -19,6 +22,14 @@ public class RunningController {
 
   @PostMapping
   public SuccessResponse createRunning(@RequestBody RunningCreateRequest runningCreateDto) {
-    return SuccessResponse.of(ExampleErrorCode.SUCCESS, runningPreparationService.createRunning(runningCreateDto));
+    return SuccessResponse.of(ExampleErrorCode.SUCCESS,
+        runningPreparationService.createRunning(runningCreateDto));
+  }
+
+  @GetMapping("/{runningId}/participants")
+  public SuccessResponse joinedParticipants(@PathVariable String runningId) {
+    List<JoinedParticipantsDto> joinedParticipants = runningPreparationService.getJoinedParticipants(
+        runningId);
+    return SuccessResponse.of(ExampleErrorCode.SUCCESS, joinedParticipants);
   }
 }

--- a/src/main/java/com/run_us/server/domains/running/controller/model/enums/SocketResponseCode.java
+++ b/src/main/java/com/run_us/server/domains/running/controller/model/enums/SocketResponseCode.java
@@ -1,5 +1,6 @@
-package com.run_us.server.global.exceptions.enums;
+package com.run_us.server.domains.running.controller.model.enums;
 
+import com.run_us.server.global.exceptions.enums.CustomResponseCode;
 import org.springframework.http.HttpStatus;
 
 /**

--- a/src/main/java/com/run_us/server/domains/running/exceptions/RunningNotFoundException.java
+++ b/src/main/java/com/run_us/server/domains/running/exceptions/RunningNotFoundException.java
@@ -1,0 +1,20 @@
+package com.run_us.server.domains.running.exceptions;
+
+import com.run_us.server.global.exceptions.BusinessException;
+import com.run_us.server.global.exceptions.enums.CustomResponseCode;
+
+public class RunningNotFoundException extends BusinessException {
+
+  protected RunningNotFoundException(
+      CustomResponseCode errorCode) {
+    super(errorCode);
+  }
+
+  protected RunningNotFoundException(CustomResponseCode errorCode, String logMessage) {
+    super(errorCode, logMessage);
+  }
+
+  public static RunningNotFoundException of(CustomResponseCode errorCode) {
+    return new RunningNotFoundException(errorCode);
+  }
+}

--- a/src/main/java/com/run_us/server/domains/running/repository/RunningRepository.java
+++ b/src/main/java/com/run_us/server/domains/running/repository/RunningRepository.java
@@ -1,6 +1,7 @@
 package com.run_us.server.domains.running.repository;
 
 import com.run_us.server.domains.running.domain.Running;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
@@ -9,5 +10,5 @@ import org.springframework.stereotype.Repository;
 public interface RunningRepository extends JpaRepository<Running, Long> {
 
   @Query("SELECT r FROM Running r WHERE r.publicKey = :publicKey")
-  Running findByPublicKey(String publicKey);
+  Optional<Running> findByPublicKey(String publicKey);
 }

--- a/src/main/java/com/run_us/server/domains/running/service/RunningResultService.java
+++ b/src/main/java/com/run_us/server/domains/running/service/RunningResultService.java
@@ -4,6 +4,8 @@ import com.run_us.server.domains.running.domain.LocationData;
 import com.run_us.server.domains.running.domain.PersonalRecord;
 import com.run_us.server.domains.running.domain.Running;
 import com.run_us.server.domains.running.domain.RunningType;
+import com.run_us.server.domains.running.exceptions.RunningErrorCode;
+import com.run_us.server.domains.running.exceptions.RunningNotFoundException;
 import com.run_us.server.domains.running.repository.PersonalRecordRepository;
 import com.run_us.server.domains.running.repository.RunningRepository;
 import com.run_us.server.domains.user.model.User;
@@ -31,7 +33,8 @@ public class RunningResultService {
    */
   @Transactional
   public void saveRunningResult(String runningId, String userId, List<LocationData> locationUpdates) {
-    Running running = runningRepository.findByPublicKey(runningId);
+    Running running = runningRepository.findByPublicKey(runningId)
+        .orElseThrow(() -> RunningNotFoundException.of(RunningErrorCode.RE001));
     User user = userRepository.findByPublicId(userId).orElseThrow(IllegalArgumentException::new);
     PersonalRecord personalRecord = PersonalRecord.builder()
         .runningId(running.getId())

--- a/src/main/java/com/run_us/server/domains/user/repository/UserRepository.java
+++ b/src/main/java/com/run_us/server/domains/user/repository/UserRepository.java
@@ -1,6 +1,8 @@
 package com.run_us.server.domains.user.repository;
 
+import com.run_us.server.domains.running.controller.JoinedParticipantsDto;
 import com.run_us.server.domains.user.model.User;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -13,4 +15,8 @@ public interface UserRepository extends JpaRepository<User, Long>{
 
   @Query("SELECT u FROM User u WHERE u.publicId = :publicId AND u.deletedAt IS NULL")
   Optional<User> findByPublicId(String publicId);
+
+  @Query("SELECT new com.run_us.server.domains.running.controller.JoinedParticipantsDto(u.nickname, u.imgUrl)"
+      + " FROM User u WHERE u.id IN :participantIds")
+  List<JoinedParticipantsDto> findSimpleParticipantsByRunningId(List<Long> participantIds);
 }

--- a/src/test/java/com/run_us/server/domains/running/RunningControllerTest.java
+++ b/src/test/java/com/run_us/server/domains/running/RunningControllerTest.java
@@ -9,6 +9,7 @@ import com.run_us.server.domains.running.service.RunningPreparationService;
 import com.run_us.server.domains.user.model.User;
 import com.run_us.server.domains.user.model.UserFixtures;
 import com.run_us.server.domains.user.repository.UserRepository;
+import com.run_us.server.global.common.SuccessResponse;
 import java.util.List;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -28,9 +29,6 @@ class RunningControllerTest {
 
   @Autowired
   private RunningController runningController;
-
-  @Autowired
-  private RunningPreparationService runningPreparationService;
 
   @Autowired
   private UserRepository userRepository;
@@ -63,10 +61,9 @@ class RunningControllerTest {
       // given
       String runningId = r1.getPublicKey();
       // when
-      List<JoinedParticipantsDto> joinedParticipants = runningPreparationService.getJoinedParticipants(
-          runningId);
-      // then
-      Assertions.assertFalse(joinedParticipants.isEmpty());
+      SuccessResponse successResponse = runningController.joinedParticipants(runningId);
+      List<JoinedParticipantsDto> joinedParticipants = (List<JoinedParticipantsDto>) successResponse.getPayload();
+      //then
       Assertions.assertEquals(2, joinedParticipants.size());
     }
   }

--- a/src/test/java/com/run_us/server/domains/running/RunningControllerTest.java
+++ b/src/test/java/com/run_us/server/domains/running/RunningControllerTest.java
@@ -1,0 +1,74 @@
+package com.run_us.server.domains.running;
+
+import com.run_us.server.config.TestRedisConfiguration;
+import com.run_us.server.domains.running.controller.JoinedParticipantsDto;
+import com.run_us.server.domains.running.controller.RunningController;
+import com.run_us.server.domains.running.domain.Running;
+import com.run_us.server.domains.running.repository.RunningRepository;
+import com.run_us.server.domains.running.service.RunningPreparationService;
+import com.run_us.server.domains.user.model.User;
+import com.run_us.server.domains.user.model.UserFixtures;
+import com.run_us.server.domains.user.repository.UserRepository;
+import java.util.List;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@Import(TestRedisConfiguration.class)
+@ActiveProfiles("test")
+@DisplayName("RunningController 테스트의")
+class RunningControllerTest {
+
+  @Autowired
+  private RunningController runningController;
+
+  @Autowired
+  private RunningPreparationService runningPreparationService;
+
+  @Autowired
+  private UserRepository userRepository;
+
+  @Autowired
+  private RunningRepository runningRepository;
+
+  @Nested
+  @DisplayName("fetchRunningParticipants 메소드는")
+  class Describe_fetchRunningParticipants {
+
+    private Running r1;
+
+    @BeforeEach
+    void setUp() {
+      // save users
+      User u1 = UserFixtures.getDefaultUserWithNickname("us1");
+      User u2 = UserFixtures.getDefaultUserWithNickname("us2");
+      userRepository.saveAndFlush(u1);
+      userRepository.saveAndFlush(u2);
+
+      // create running
+      r1 = RunningFixtures.getDefaultRunningWithParticipants(List.of(u1, u2));
+      runningRepository.saveAndFlush(r1);
+    }
+
+    @DisplayName("참가자 목록을 반환한다")
+    @Test
+    void it_returns_participants() {
+      // given
+      String runningId = r1.getPublicKey();
+      // when
+      List<JoinedParticipantsDto> joinedParticipants = runningPreparationService.getJoinedParticipants(
+          runningId);
+      // then
+      Assertions.assertFalse(joinedParticipants.isEmpty());
+      Assertions.assertEquals(2, joinedParticipants.size());
+    }
+  }
+
+}

--- a/src/test/java/com/run_us/server/domains/running/RunningFixtures.java
+++ b/src/test/java/com/run_us/server/domains/running/RunningFixtures.java
@@ -3,7 +3,9 @@ package com.run_us.server.domains.running;
 import com.run_us.server.domains.running.domain.Running;
 import com.run_us.server.domains.running.domain.RunningConstraints;
 import com.run_us.server.domains.running.domain.RunningDescription;
+import com.run_us.server.domains.user.model.User;
 import com.run_us.server.global.utils.PointGenerator;
+import java.util.List;
 import org.locationtech.jts.geom.Point;
 
 public final class RunningFixtures {
@@ -33,5 +35,11 @@ public final class RunningFixtures {
         .distance("10KM")
         .desc("test description")
         .build();
+  }
+
+  public static Running getDefaultRunningWithParticipants(List<User> users) {
+    Running running = getDefaultRunning();
+    users.forEach(running::addParticipant);
+    return running;
   }
 }


### PR DESCRIPTION
### 연관된 이슈를 적어주세요 📌
#11 : 유저 정보 fetch하는 요청을 http로 분리

### 작업한 내용을 설명해주세요 ✔️

- 기존 STOMP 통신에서 `/app/runnings/{runningID}`로 SUBSCRIBE시에 유저정보를 fetch하던 것을 분리함.
- ResponseCode의 위치를 해당 도메인으로 이동함.
- ErrorCode를 새로 정의하여 도메인 관련된 에러코드를 정의함.

### 트러블 슈팅
- JPA에서 간접참조한 id들의 set에 조인하려는 시도 >> 실패..

### 리뷰어에게 하고 싶은 말을 적어주세요

- JPA를 쓰다보니... CollectionTable로 만들었던 `Participants안에 있는 id들에 유저를 조인해서 한번에 끌어오기에 실패했어유 ㅠ
- 여러 방법을 써봤는데.. jdbc로 pariticpants 테이블에 직접 쿼리를 날리면 되기야하겠지만 **우선 쿼리를 두번 날리는 것**으로 했습니다.

1. RunningID를 기반으로 Running 엔티티를 쿼리함.
2. Running 엔티티의 PariticipantsId를 리스트로 받아서 
3. User table에 select .. in 으로 쿼리를 날림. 

- in을 사용해서 우선 잘 받아와지긴합니다만, participants 엔티티화 시켜서 하면 조인으로 풀 수 있긴해요. 이슈로 적어보겠습니다.

### 확인하기

- [x] : 코드에 에러가 없는지 확인했나요?
- [x] : PR에 설명을 기재했나요?
- [x] : PR 태그를 붙였나요?
- [x] : 불필요한 로그나 `System.out`을 제거했나요?