### PR TITLE
[Feat/ws auth] STOMP CONNECT 시 User 정보 세션저장, StompErrorHandler 구현

### DIFF
--- a/src/main/java/com/run_us/server/domains/test/TestController.java
+++ b/src/main/java/com/run_us/server/domains/test/TestController.java
@@ -1,11 +1,15 @@
 package com.run_us.server.domains.test;
 
+import com.run_us.server.domains.user.model.User;
 import com.run_us.server.global.common.SuccessResponse;
 import com.run_us.server.global.exceptions.enums.ExampleErrorCode;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.stereotype.Controller;
+
+import static com.run_us.server.global.common.GlobalConsts.SESSION_ATTRIBUTE_USER;
 
 /**
  * 테스트용 api 컨트롤러
@@ -27,5 +31,19 @@ public class TestController {
         //TODO : 소켓 응답 코드에 대한 논의 필요. 임시로 EXAMPLE 응답
         log.info("initTest : /topic/test/hello");
         simpMessagingTemplate.convertAndSend("/topic/test/hello", SuccessResponse.messageOnly(ExampleErrorCode.EXAMPLE));
+    }
+
+    /**
+     * ws session 사용자 정보 저장 테스트
+     */
+    @MessageMapping("/test/user/session")
+    public void userSessionTest(StompHeaderAccessor accessor) {
+        log.info("userSessionTest : /topic/test/user/session");
+        
+        // 세션에 저장된 유저 정보 가져오기
+        User user = (User) accessor.getSessionAttributes().get(SESSION_ATTRIBUTE_USER);
+        log.info("userSessionTest : user : {}", user);
+        
+        simpMessagingTemplate.convertAndSend("/topic/test/user/session", SuccessResponse.of(ExampleErrorCode.SUCCESS, user));
     }
 }

--- a/src/main/java/com/run_us/server/domains/user/model/response/UserErrorCode.java
+++ b/src/main/java/com/run_us/server/domains/user/model/response/UserErrorCode.java
@@ -1,0 +1,42 @@
+package com.run_us.server.domains.user.model.response;
+
+import com.run_us.server.global.exceptions.enums.CustomResponseCode;
+import org.springframework.http.HttpStatus;
+
+public enum UserErrorCode implements CustomResponseCode {
+
+  PUBLIC_ID_NOT_FOUND("U41001", HttpStatus.UNAUTHORIZED, "public id 에 해당하는 사용자 없음", "public id 에 해당하는 사용자 없음"),
+  ;
+
+  private final String code;
+  private final HttpStatus httpStatusCode;
+  private final String clientMessage;
+  private final String logMessage;
+
+  UserErrorCode(String code, HttpStatus httpStatusCode, String clientMessage, String logMessage) {
+    this.code = code;
+    this.httpStatusCode = httpStatusCode;
+    this.clientMessage = clientMessage;
+    this.logMessage = logMessage;
+  }
+
+  @Override
+  public String getCode() {
+    return this.code;
+  }
+
+  @Override
+  public String getClientMessage() {
+    return this.clientMessage;
+  }
+
+  @Override
+  public String getLogMessage() {
+    return this.logMessage;
+  }
+
+  @Override
+  public HttpStatus getHttpStatusCode() {
+    return this.httpStatusCode;
+  }
+}

--- a/src/main/java/com/run_us/server/domains/user/model/response/UserException.java
+++ b/src/main/java/com/run_us/server/domains/user/model/response/UserException.java
@@ -1,0 +1,19 @@
+package com.run_us.server.domains.user.model.response;
+
+import com.run_us.server.global.exceptions.BusinessException;
+import com.run_us.server.global.exceptions.enums.CustomResponseCode;
+
+public class UserException extends BusinessException {
+
+  protected UserException(CustomResponseCode errorCode, String logMessage) {
+    super(errorCode, logMessage);
+  }
+
+  protected UserException(CustomResponseCode errorCode) {
+    super(errorCode);
+  }
+
+  public static UserException of(CustomResponseCode errorCode) {
+    return new UserException(errorCode);
+  }
+}

--- a/src/main/java/com/run_us/server/domains/user/service/UserService.java
+++ b/src/main/java/com/run_us/server/domains/user/service/UserService.java
@@ -1,0 +1,22 @@
+package com.run_us.server.domains.user.service;
+
+import com.run_us.server.domains.user.model.User;
+import com.run_us.server.domains.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+    private final UserRepository userRepository;
+
+    // TODO : publicId 로 유저 찾는 로직을 이거 하나로 몰아두는 게 어떤지 (예외처리 등을 한곳에서 관리하도록)
+    /**
+     * publicId 로 유저 정보를 가져오는 메서드
+     * @param publicId
+     * @return
+     */
+    public User getUserByPublicId(String publicId) {
+        return userRepository.findByPublicId(publicId).orElseThrow(IllegalArgumentException::new); 
+    }
+}

--- a/src/main/java/com/run_us/server/domains/user/service/UserService.java
+++ b/src/main/java/com/run_us/server/domains/user/service/UserService.java
@@ -1,9 +1,12 @@
 package com.run_us.server.domains.user.service;
 
 import com.run_us.server.domains.user.model.User;
+import com.run_us.server.domains.user.model.response.UserException;
 import com.run_us.server.domains.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import static com.run_us.server.domains.user.model.response.UserErrorCode.PUBLIC_ID_NOT_FOUND;
 
 @Service
 @RequiredArgsConstructor
@@ -17,6 +20,6 @@ public class UserService {
      * @return
      */
     public User getUserByPublicId(String publicId) {
-        return userRepository.findByPublicId(publicId).orElseThrow(IllegalArgumentException::new); 
+        return userRepository.findByPublicId(publicId).orElseThrow(() -> UserException.of(PUBLIC_ID_NOT_FOUND));
     }
 }

--- a/src/main/java/com/run_us/server/global/common/GlobalConsts.java
+++ b/src/main/java/com/run_us/server/global/common/GlobalConsts.java
@@ -5,4 +5,6 @@ public final class GlobalConsts {
   public static final String DEFAULT_IMG_URL = "default_img_url";
 
   public static final String RUNNING_WS_SEND_PREFIX = "/topic/runnings/";
+  public static final String WS_USER_AUTH_HEADER = "user-id";
+  public static final String SESSION_ATTRIBUTE_USER = "user-info";
 }

--- a/src/main/java/com/run_us/server/global/config/WebSocketConfig.java
+++ b/src/main/java/com/run_us/server/global/config/WebSocketConfig.java
@@ -1,6 +1,7 @@
 package com.run_us.server.global.config;
 
 import com.run_us.server.domains.running.controller.StompInterceptor;
+import com.run_us.server.global.exceptions.StompErrorHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
@@ -19,10 +20,13 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     private final StompInterceptor stompInterceptor;
+    private final StompErrorHandler stompErrorHandler;
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint("/ws-hello").setAllowedOriginPatterns("*"); // ws 연결 요청 - 모든 곳으로부터의 요청 허용
+
+        registry.setErrorHandler(stompErrorHandler);
     }
 
     @Override

--- a/src/main/java/com/run_us/server/global/exceptions/StompErrorHandler.java
+++ b/src/main/java/com/run_us/server/global/exceptions/StompErrorHandler.java
@@ -1,0 +1,33 @@
+package com.run_us.server.global.exceptions;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.web.socket.messaging.StompSubProtocolErrorHandler;
+
+import java.nio.charset.StandardCharsets;
+
+@Slf4j
+@Configuration
+public class StompErrorHandler extends StompSubProtocolErrorHandler {
+
+    @Override
+    public Message<byte[]> handleClientMessageProcessingError(Message<byte[]> clientMessage, Throwable ex) {
+
+        Throwable cause = ex.getCause();
+        if(cause instanceof BusinessException) {
+            return createErrorMessage((BusinessException) cause); // TODO : 여기서 대신 GlobalExceptionHandler 의 메서드를 호출해서 로직을 모아둘 수도 있음
+        }
+
+        return super.handleClientMessageProcessingError(clientMessage, ex);
+    }
+
+    private Message<byte[]> createErrorMessage(BusinessException exception) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.ERROR);
+        String errorMessage = exception.getLogMessage();
+        return MessageBuilder.createMessage(errorMessage.getBytes(StandardCharsets.UTF_8), accessor.getMessageHeaders());
+    }
+}


### PR DESCRIPTION
### 연관된 이슈를 적어주세요 📌
x

### 작업한 내용을 설명해주세요 ✔️

- STOMP CONNECT request 시 유저 정보 저장
CONNECT 요청의 헤더 user-id 의 user public key (TSID) 값을 이용해 유저 정보를 조회한 후 session 에 저장합니다.
저장 이후에는 다음과 같이 User 객체를 세션에서 확인할 수 있습니다.
  ```
  User user = accessor.getSessionAttributes().get(SESSION_ATTRIBUTE_USER));
  ```


- STOMP CONNECT request 시 유저 정보 저장 : 테스트용 요청 구현
해당 로직을 테스트해볼 수 있는 요청을 하나 구현했습니다. 
CONNECT 시 세션에 저장된 사용자 정보를 구독한 경로로 받아볼 수 있습니다.
포스트맨에 테스트 요청 만들어뒀으며 다음과 같은 순서로 테스트 작동 가능합니다.
  1. CONNECT : user-id 헤더 추가
  2. SUBSCRIBE : /topic/test/user/session
  3. SEND : /app/test/user/session
![image](https://github.com/user-attachments/assets/29ffd8b5-f7a7-488d-b84e-ee226809bdf6)
![image](https://github.com/user-attachments/assets/2e579c80-3249-42d8-b0e8-614acd67b7ad)
![image](https://github.com/user-attachments/assets/7a954097-61e4-4742-bcf8-c991d9eca116)


- StompErrorHandler 구현
STOMP 통신 상에서 발생하는 에러 중, 커스텀클래스 BusinessException 로 던지는 예외를 잡아 처리할 수 있도록 했습니다. 
  - 인터셉터 등 컨트롤러 밖에서 발생하는 것도 잡아줍니다.
  - 에러 발생 시 커스텀 에러코드의 메세지가 클라이언트에게 전달됩니다.
![image](https://github.com/user-attachments/assets/e44c39ad-073e-40ea-afbb-3da706dbd937)

- 그 외 UserErrorCode 와 UserException 만들어서 패키지 여기에 넣었는데 저희 룰과 맞는지 확인 한번 부탁드려요!
![image](https://github.com/user-attachments/assets/51b6e5ab-17ba-4b86-9b1f-8f9c67c0f1f2)


### 트러블 슈팅
x

### 리뷰어에게 하고 싶은 말을 적어주세요
[질문]
1. 저희 ResponseCode 에서 U001 이 코드값은 ResponseCode 로 커스텀 Exception 만들 때 안가져가더라구요..? (버려짐) 
코드값은 클라이언트에는 전달 안할 예정일까요?
2. public key 값으로 DB에서 User 객체 가져오는 로직은 
UserService 에 만든 getUserByPublicId() 메서드만 사용하게 하는 거 어떨까요?
로직 한군데로 몰고 싶어서 제안해봅니다.

리뷰 감사함다~~

### 확인하기

- [x] : 코드에 에러가 없는지 확인했나요?
- [x] : PR에 설명을 기재했나요?
- [x] : PR 태그를 붙였나요?
- [x] : 불필요한 로그나 `System.out`을 제거했나요?