### PR TITLE
[Feature/validate subscribe] - 채널 구독시 검증로직 추가

### DIFF
--- a/src/main/java/com/run_us/server/domains/running/controller/StompInterceptor.java
+++ b/src/main/java/com/run_us/server/domains/running/controller/StompInterceptor.java
@@ -3,6 +3,7 @@ package com.run_us.server.domains.running.controller;
 import static com.run_us.server.global.common.GlobalConsts.SESSION_ATTRIBUTE_USER;
 import static com.run_us.server.global.common.GlobalConsts.WS_USER_AUTH_HEADER;
 
+import com.run_us.server.domains.running.service.SubscriptionService;
 import com.run_us.server.domains.user.domain.User;
 import com.run_us.server.domains.user.service.UserService;
 import java.util.Map;

--- a/src/main/java/com/run_us/server/domains/running/controller/StompInterceptor.java
+++ b/src/main/java/com/run_us/server/domains/running/controller/StompInterceptor.java
@@ -1,7 +1,12 @@
 package com.run_us.server.domains.running.controller;
 
+import static com.run_us.server.global.common.GlobalConsts.SESSION_ATTRIBUTE_USER;
+import static com.run_us.server.global.common.GlobalConsts.WS_USER_AUTH_HEADER;
+
 import com.run_us.server.domains.user.domain.User;
 import com.run_us.server.domains.user.service.UserService;
+import java.util.Map;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.Message;
@@ -9,11 +14,6 @@ import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.messaging.support.ChannelInterceptor;
 import org.springframework.stereotype.Component;
-
-import java.util.Map;
-
-import static com.run_us.server.global.common.GlobalConsts.SESSION_ATTRIBUTE_USER;
-import static com.run_us.server.global.common.GlobalConsts.WS_USER_AUTH_HEADER;
 
 
 /**
@@ -26,20 +26,21 @@ import static com.run_us.server.global.common.GlobalConsts.WS_USER_AUTH_HEADER;
 @RequiredArgsConstructor
 public class StompInterceptor implements ChannelInterceptor {
   private final UserService userService;
+  private final SubscriptionService subscriptionService;
 
   @Override
   public Message<?> preSend(Message<?> message, MessageChannel channel) {
 
     StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
 
-    switch (accessor.getCommand()) { // TODO: 인증, 인가, 권한 체크
+    switch (Objects.requireNonNull(accessor.getCommand())) { // TODO: 인증, 인가, 권한 체크
       case CONNECT -> {
         log.info("CONNECT");
         setUserInfoInSession(accessor);
       }
       case SUBSCRIBE -> {
         log.info("SUBSCRIBE : {} by {}", accessor.getDestination(), accessor.getSubscriptionId());
-        validateSubscription(accessor);
+        subscriptionService.process(Objects.requireNonNull(accessor.getDestination()), accessor.getSubscriptionId());
       }
     }
     return message;
@@ -56,13 +57,5 @@ public class StompInterceptor implements ChannelInterceptor {
     sessionAttributes.put(SESSION_ATTRIBUTE_USER, user);
     accessor.setSessionAttributes(sessionAttributes);
 //    log.info("CONNECT setUserInfoInSession : {}", accessor.getSessionAttributes().get(SESSION_ATTRIBUTE_USER));
-  }
-
-  private void validateSubscription(StompHeaderAccessor accessor) {
-    if (accessor.getDestination().startsWith("/topic")) {
-      log.info("Validated subscription to topic {}", accessor.getDestination());
-    } else {
-      log.warn("Invalid subscription to topic {}", accessor.getDestination());
-    }
   }
 }

--- a/src/main/java/com/run_us/server/domains/running/controller/SubscriptionService.java
+++ b/src/main/java/com/run_us/server/domains/running/controller/SubscriptionService.java
@@ -1,0 +1,29 @@
+package com.run_us.server.domains.running.controller;
+
+import com.run_us.server.domains.running.controller.model.enums.SubscriptionTopic;
+import com.run_us.server.domains.running.service.RunningPreparationService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SubscriptionService {
+    private static final int TOPIC_INDEX = 2;
+    private static final int SESSION_ID_INDEX = 3;
+    private final RunningPreparationService runningPreparationService;
+
+    public void process(String destination, String userId) {
+      String[] destinationTokens = destination.split("/");
+
+      switch (SubscriptionTopic.from(destinationTokens[TOPIC_INDEX])) {
+        case RUNNING -> handleRunningTopic(destinationTokens[SESSION_ID_INDEX], userId);
+        //TODO: unicast를 위한 queue 구현
+        case QUEUE -> {}
+      }
+    }
+    private void handleRunningTopic(String runningId, String userId) {
+      runningPreparationService.joinRunning(runningId, userId);
+    }
+}

--- a/src/main/java/com/run_us/server/domains/running/controller/model/enums/SubscriptionTopic.java
+++ b/src/main/java/com/run_us/server/domains/running/controller/model/enums/SubscriptionTopic.java
@@ -1,12 +1,15 @@
 package com.run_us.server.domains.running.controller.model.enums;
 
+import static com.run_us.server.global.common.GlobalConsts.RUNNING_WS_SUBSCRIBE_TOKEN;
+import static com.run_us.server.global.common.GlobalConsts.USER_WS_SUBSCRIBE_TOKEN;
+
 import lombok.Getter;
 
 @Getter
 public enum SubscriptionTopic {
 
-  RUNNING("running"),
-  QUEUE("queue"),
+  RUNNING(RUNNING_WS_SUBSCRIBE_TOKEN),
+  QUEUE(USER_WS_SUBSCRIBE_TOKEN),
   ERROR("error");
 
   private final String topic;

--- a/src/main/java/com/run_us/server/domains/running/controller/model/enums/SubscriptionTopic.java
+++ b/src/main/java/com/run_us/server/domains/running/controller/model/enums/SubscriptionTopic.java
@@ -1,15 +1,15 @@
 package com.run_us.server.domains.running.controller.model.enums;
 
-import static com.run_us.server.global.common.GlobalConsts.RUNNING_WS_SUBSCRIBE_TOKEN;
-import static com.run_us.server.global.common.GlobalConsts.USER_WS_SUBSCRIBE_TOKEN;
+import static com.run_us.server.global.common.GlobalConsts.RUNNING_WS_SUBSCRIBE_PATH;
+import static com.run_us.server.global.common.GlobalConsts.USER_WS_SUBSCRIBE_PATH;
 
 import lombok.Getter;
 
 @Getter
 public enum SubscriptionTopic {
 
-  RUNNING(RUNNING_WS_SUBSCRIBE_TOKEN),
-  QUEUE(USER_WS_SUBSCRIBE_TOKEN),
+  RUNNING(RUNNING_WS_SUBSCRIBE_PATH),
+  QUEUE(USER_WS_SUBSCRIBE_PATH),
   ERROR("error");
 
   private final String topic;

--- a/src/main/java/com/run_us/server/domains/running/controller/model/enums/SubscriptionTopic.java
+++ b/src/main/java/com/run_us/server/domains/running/controller/model/enums/SubscriptionTopic.java
@@ -1,0 +1,35 @@
+package com.run_us.server.domains.running.controller.model.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum SubscriptionTopic {
+
+  RUNNING("running"),
+  QUEUE("queue"),
+  ERROR("error");
+
+  private final String topic;
+
+  SubscriptionTopic(String topic) {
+    this.topic = topic;
+  }
+
+  public static SubscriptionTopic from(String topic) {
+    for (SubscriptionTopic subscriptionTopic : SubscriptionTopic.values()) {
+      if (subscriptionTopic.getTopic().equals(topic)) {
+        return subscriptionTopic;
+      }
+    }
+    throw new IllegalArgumentException("Invalid topic: " + topic);
+  }
+
+  public static boolean contains(String topic) {
+    for (SubscriptionTopic subscriptionTopic : SubscriptionTopic.values()) {
+      if (subscriptionTopic.getTopic().equals(topic)) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/src/main/java/com/run_us/server/domains/running/service/SubscriptionService.java
+++ b/src/main/java/com/run_us/server/domains/running/service/SubscriptionService.java
@@ -1,7 +1,6 @@
-package com.run_us.server.domains.running.controller;
+package com.run_us.server.domains.running.service;
 
 import com.run_us.server.domains.running.controller.model.enums.SubscriptionTopic;
-import com.run_us.server.domains.running.service.RunningPreparationService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/run_us/server/global/common/GlobalConsts.java
+++ b/src/main/java/com/run_us/server/global/common/GlobalConsts.java
@@ -14,8 +14,8 @@ public final class GlobalConsts {
   public static final String WS_DESTINATION_PREFIX_QUEUE = "/queue";
 
   public static final String RUNNING_WS_SEND_PREFIX = "/topic/runnings/";
-  public static final String RUNNING_WS_SUBSCRIBE_TOKEN = "runnings";
-  public static final String USER_WS_SUBSCRIBE_TOKEN = "queue";
+  public static final String RUNNING_WS_SUBSCRIBE_PATH = "runnings";
+  public static final String USER_WS_SUBSCRIBE_PATH = "queue";
 
   public static final String WS_USER_AUTH_HEADER = "user-id";
   public static final String SESSION_ATTRIBUTE_USER = "user-info";

--- a/src/main/java/com/run_us/server/global/common/GlobalConsts.java
+++ b/src/main/java/com/run_us/server/global/common/GlobalConsts.java
@@ -1,5 +1,9 @@
 package com.run_us.server.global.common;
 
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class GlobalConsts {
   public static final String TIME_ZONE_ID = "Asia/Seoul";
   public static final String DEFAULT_IMG_URL = "default_img_url";
@@ -10,6 +14,8 @@ public final class GlobalConsts {
   public static final String WS_DESTINATION_PREFIX_QUEUE = "/queue";
 
   public static final String RUNNING_WS_SEND_PREFIX = "/topic/runnings/";
+  public static final String RUNNING_WS_SUBSCRIBE_TOKEN = "runnings";
+  public static final String USER_WS_SUBSCRIBE_TOKEN = "queue";
 
   public static final String WS_USER_AUTH_HEADER = "user-id";
   public static final String SESSION_ATTRIBUTE_USER = "user-info";

--- a/src/test/java/com/run_us/server/domains/running/controller/model/enums/SubscriptionTopicTest.java
+++ b/src/test/java/com/run_us/server/domains/running/controller/model/enums/SubscriptionTopicTest.java
@@ -1,5 +1,7 @@
 package com.run_us.server.domains.running.controller.model.enums;
 
+import static com.run_us.server.global.common.GlobalConsts.RUNNING_WS_SUBSCRIBE_TOKEN;
+import static com.run_us.server.global.common.GlobalConsts.USER_WS_SUBSCRIBE_TOKEN;
 import static org.junit.jupiter.api.Assertions.*;
 
 import org.junit.jupiter.api.DisplayName;
@@ -20,8 +22,8 @@ class SubscriptionTopicTest {
       @DisplayName("해당 topic을 반환한다")
       @Test
       void it_returns_the_topic() {
-        assertEquals(SubscriptionTopic.RUNNING, SubscriptionTopic.from("running"));
-        assertEquals(SubscriptionTopic.QUEUE, SubscriptionTopic.from("queue"));
+        assertEquals(SubscriptionTopic.RUNNING, SubscriptionTopic.from(RUNNING_WS_SUBSCRIBE_TOKEN));
+        assertEquals(SubscriptionTopic.QUEUE, SubscriptionTopic.from(USER_WS_SUBSCRIBE_TOKEN));
         assertEquals(SubscriptionTopic.ERROR, SubscriptionTopic.from("error"));
       }
     }
@@ -49,8 +51,8 @@ class SubscriptionTopicTest {
       @DisplayName("true를 반환한다")
       @Test
       void it_returns_true() {
-        assertTrue(SubscriptionTopic.contains("running"));
-        assertTrue(SubscriptionTopic.contains("queue"));
+        assertTrue(SubscriptionTopic.contains(RUNNING_WS_SUBSCRIBE_TOKEN));
+        assertTrue(SubscriptionTopic.contains(USER_WS_SUBSCRIBE_TOKEN));
         assertTrue(SubscriptionTopic.contains("error"));
       }
     }

--- a/src/test/java/com/run_us/server/domains/running/controller/model/enums/SubscriptionTopicTest.java
+++ b/src/test/java/com/run_us/server/domains/running/controller/model/enums/SubscriptionTopicTest.java
@@ -1,7 +1,7 @@
 package com.run_us.server.domains.running.controller.model.enums;
 
-import static com.run_us.server.global.common.GlobalConsts.RUNNING_WS_SUBSCRIBE_TOKEN;
-import static com.run_us.server.global.common.GlobalConsts.USER_WS_SUBSCRIBE_TOKEN;
+import static com.run_us.server.global.common.GlobalConsts.RUNNING_WS_SUBSCRIBE_PATH;
+import static com.run_us.server.global.common.GlobalConsts.USER_WS_SUBSCRIBE_PATH;
 import static org.junit.jupiter.api.Assertions.*;
 
 import org.junit.jupiter.api.DisplayName;
@@ -22,8 +22,8 @@ class SubscriptionTopicTest {
       @DisplayName("해당 topic을 반환한다")
       @Test
       void it_returns_the_topic() {
-        assertEquals(SubscriptionTopic.RUNNING, SubscriptionTopic.from(RUNNING_WS_SUBSCRIBE_TOKEN));
-        assertEquals(SubscriptionTopic.QUEUE, SubscriptionTopic.from(USER_WS_SUBSCRIBE_TOKEN));
+        assertEquals(SubscriptionTopic.RUNNING, SubscriptionTopic.from(RUNNING_WS_SUBSCRIBE_PATH));
+        assertEquals(SubscriptionTopic.QUEUE, SubscriptionTopic.from(USER_WS_SUBSCRIBE_PATH));
         assertEquals(SubscriptionTopic.ERROR, SubscriptionTopic.from("error"));
       }
     }
@@ -51,8 +51,8 @@ class SubscriptionTopicTest {
       @DisplayName("true를 반환한다")
       @Test
       void it_returns_true() {
-        assertTrue(SubscriptionTopic.contains(RUNNING_WS_SUBSCRIBE_TOKEN));
-        assertTrue(SubscriptionTopic.contains(USER_WS_SUBSCRIBE_TOKEN));
+        assertTrue(SubscriptionTopic.contains(RUNNING_WS_SUBSCRIBE_PATH));
+        assertTrue(SubscriptionTopic.contains(USER_WS_SUBSCRIBE_PATH));
         assertTrue(SubscriptionTopic.contains("error"));
       }
     }

--- a/src/test/java/com/run_us/server/domains/running/controller/model/enums/SubscriptionTopicTest.java
+++ b/src/test/java/com/run_us/server/domains/running/controller/model/enums/SubscriptionTopicTest.java
@@ -1,0 +1,70 @@
+package com.run_us.server.domains.running.controller.model.enums;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("SubscriptionTopic 클래스의")
+class SubscriptionTopicTest {
+
+  @Nested
+  @DisplayName("from 메소드는")
+  class Describe_from {
+
+    @Nested
+    @DisplayName("존재하는 topic을 입력받았을 때")
+    class Context_with_existing_topic {
+
+      @DisplayName("해당 topic을 반환한다")
+      @Test
+      void it_returns_the_topic() {
+        assertEquals(SubscriptionTopic.RUNNING, SubscriptionTopic.from("running"));
+        assertEquals(SubscriptionTopic.QUEUE, SubscriptionTopic.from("queue"));
+        assertEquals(SubscriptionTopic.ERROR, SubscriptionTopic.from("error"));
+      }
+    }
+
+    @Nested
+    @DisplayName("존재하지 않는 topic을 입력받았을 때")
+    class Context_with_non_existing_topic {
+
+      @DisplayName("IllegalArgumentException을 던진다")
+      @Test
+      void it_throws_IllegalArgumentException() {
+        assertThrows(IllegalArgumentException.class, () -> SubscriptionTopic.from("non-existing-topic"));
+      }
+    }
+  }
+
+  @Nested
+  @DisplayName("contains 메소드는")
+  class Describe_contains {
+
+    @Nested
+    @DisplayName("존재하는 topic을 입력받았을 때")
+    class Context_with_existing_topic {
+
+      @DisplayName("true를 반환한다")
+      @Test
+      void it_returns_true() {
+        assertTrue(SubscriptionTopic.contains("running"));
+        assertTrue(SubscriptionTopic.contains("queue"));
+        assertTrue(SubscriptionTopic.contains("error"));
+      }
+    }
+
+    @Nested
+    @DisplayName("존재하지 않는 topic을 입력받았을 때")
+    class Context_with_non_existing_topic {
+
+      @DisplayName("false를 반환한다")
+      @Test
+      void it_returns_false() {
+        assertFalse(SubscriptionTopic.contains("non-existing-topic"));
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
### 연관된 이슈를 적어주세요 📌
- 기존 코드에서는 subscribe 요청을 존재하지 않는 `destination_path`로 보내도 거절하거나 에러메세지를 반환하지 않았음.

### 작업한 내용을 설명해주세요 ✔️

**1. subscribe 시 topic에 따라 검증로직을 추가**
  - user-unicast를 위한 `user` (미구현)
  - 실시간 달리기 채널을 위한 `runnings` (구현)

**검증로직 추가에 따른 시퀀스 다이어그램**
![Screenshot 2024-10-01 at 2 27 48 PM](https://github.com/user-attachments/assets/d1684190-dbde-44e7-ad46-b7bf23fcb441)

---

**2. topic을 구분하기 위한 Enum추가**
  - 토픽이 추가되면 Enum에 새로 정의합니다.
  - 유저가 전송한 `destination_path`를 토큰화하여 토픽을 추출하고 일치하는 토픽이 있으면 처리합니다. 


**부적절한 RunningId를 사용하여 Subscribe요청을 보낸 경우**

<img width="856" alt="Screenshot 2024-10-01 at 2 56 08 PM" src="https://github.com/user-attachments/assets/0284c2ab-6210-405e-8df4-ce28d7a97eb8">




---
### 트러블 슈팅
- 시큐리티에 `path`가 허용되지 않아 로컬환경에서 

```java
.authorizeHttpRequests(authorize -> authorize
                        .requestMatchers("/runnings/**").permitAll()  // 임시로 추가하고 실행
                        .requestMatchers("/auth/**").permitAll()
                        .requestMatchers(GlobalConsts.WS_CONNECT_ENDPOINT).permitAll()
                        .anyRequest().authenticated()
                )

```

임시로 추가하고 진행했습니다.

---

### 리뷰어에게 하고 싶은 말을 적어주세요

### 확인하기

- [ ] : 코드에 에러가 없는지 확인했나요?
- [ ] : PR에 설명을 기재했나요?
- [ ] : PR 태그를 붙였나요?
- [ ] : 불필요한 로그나 `System.out`을 제거했나요?