### PR TITLE
[Fix/send to user] - 특정유저에게 전송하기 수정

### DIFF
--- a/src/main/java/com/run_us/server/domains/running/controller/RunningSocketController.java
+++ b/src/main/java/com/run_us/server/domains/running/controller/RunningSocketController.java
@@ -4,23 +4,26 @@ import com.run_us.server.domains.running.controller.model.enums.RunningResponseC
 import com.run_us.server.domains.running.controller.model.request.RunningRequest;
 import com.run_us.server.domains.running.controller.model.request.RunningRequest.LocationUpdate;
 import com.run_us.server.domains.running.controller.model.response.RunningResponse;
+import com.run_us.server.domains.running.exceptions.RunningErrorCode;
 import com.run_us.server.domains.running.service.RunningLiveService;
 import com.run_us.server.domains.running.service.RunningPreparationService;
 import com.run_us.server.domains.running.service.RunningResultService;
+import com.run_us.server.global.common.ErrorResponse;
 import com.run_us.server.global.common.GlobalConsts;
 import com.run_us.server.global.common.SuccessResponse;
+import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.Message;
+import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
 import org.springframework.messaging.simp.SimpMessageSendingOperations;
+import org.springframework.messaging.simp.SimpMessageType;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Controller;
 
-/**
- * 러닝 websocket 컨트롤러
- */
+/** 러닝 websocket 컨트롤러 */
 @Slf4j
 @RequiredArgsConstructor
 @Controller
@@ -32,7 +35,7 @@ public class RunningSocketController {
   private final RunningLiveService runningLiveService;
   private final RunningPreparationService runningPreparationService;
   private final RunningResultService runningResultService;
-  
+
   /**
    * 러닝 시작
    *
@@ -53,13 +56,16 @@ public class RunningSocketController {
    */
   @MessageMapping("/users/runnings/location")
   public void updateLocation(LocationUpdate requestDto) {
-    runningLiveService.updateLocation(requestDto.getRunningId(), requestDto.getUserId(),
-        requestDto.getLatitude(), requestDto.getLongitude(),
+    runningLiveService.updateLocation(
+        requestDto.getRunningId(),
+        requestDto.getUserId(),
+        requestDto.getLatitude(),
+        requestDto.getLongitude(),
         requestDto.getCount());
     simpMessagingTemplate.convertAndSend(
         GlobalConsts.RUNNING_WS_SEND_PREFIX + requestDto.getRunningId(),
-        SuccessResponse.of(RunningResponseCode.UPDATE_LOCATION,
-            RunningResponse.LocationData.toDto(requestDto)));
+        SuccessResponse.of(
+            RunningResponseCode.UPDATE_LOCATION, RunningResponse.LocationData.toDto(requestDto)));
   }
 
   /***
@@ -94,7 +100,7 @@ public class RunningSocketController {
    */
   @MessageMapping("/users/runnings/end")
   public void endRunning(RunningRequest.StopRunning requestDto) {
-    //TODO:check if the user is the owner of the running session
+    // TODO:check if the user is the owner of the running session
     log.info("endRunning : {}", requestDto.getRunningId());
     runningLiveService.endRunning(requestDto.getRunningId(), requestDto.getUserId());
     simpMessagingTemplate.convertAndSend(
@@ -124,5 +130,14 @@ public class RunningSocketController {
   private String getSubscriptionId(Message<?> message) {
     SimpMessageHeaderAccessor headerAccessor = SimpMessageHeaderAccessor.wrap(message);
     return headerAccessor.getSubscriptionId();
+  }
+
+  private void sendToUser(@NotNull String sessionId, @NotNull String destination, Object payload) {
+    SimpMessageHeaderAccessor headerAccessor =
+        SimpMessageHeaderAccessor.create(SimpMessageType.MESSAGE);
+    headerAccessor.setSessionId(sessionId);
+    headerAccessor.setLeaveMutable(true);
+    simpMessageSendingOperations.convertAndSendToUser(
+        sessionId, destination, payload, headerAccessor.getMessageHeaders());
   }
 }

--- a/src/main/java/com/run_us/server/domains/running/controller/model/enums/SubscriptionTopic.java
+++ b/src/main/java/com/run_us/server/domains/running/controller/model/enums/SubscriptionTopic.java
@@ -10,6 +10,7 @@ public enum SubscriptionTopic {
 
   RUNNING(RUNNING_WS_SUBSCRIBE_PATH),
   QUEUE(USER_WS_SUBSCRIBE_PATH),
+  LOG("logs"),
   ERROR("error");
 
   private final String topic;

--- a/src/main/java/com/run_us/server/domains/running/exceptions/RunningErrorCode.java
+++ b/src/main/java/com/run_us/server/domains/running/exceptions/RunningErrorCode.java
@@ -5,7 +5,9 @@ import org.springframework.http.HttpStatus;
 
 public enum RunningErrorCode implements CustomResponseCode {
 
-  RUNNING_NOT_FOUND("RE001", "Running not found", "Running not found", HttpStatus.NOT_FOUND);
+  RUNNING_NOT_FOUND("RE001", "Running not found", "Running not found", HttpStatus.NOT_FOUND),
+  AGGREGATE_FAILED("RE4001", "Failed to Save Running Result", "Failed to Save Running Result",
+      HttpStatus.BAD_REQUEST),;
 
 
   private final String code;

--- a/src/main/java/com/run_us/server/domains/running/service/SubscriptionService.java
+++ b/src/main/java/com/run_us/server/domains/running/service/SubscriptionService.java
@@ -20,6 +20,7 @@ public class SubscriptionService {
         case RUNNING -> handleRunningTopic(destinationTokens[SESSION_ID_INDEX], userId);
         //TODO: unicast를 위한 queue 구현
         case QUEUE -> {}
+        default -> log.error("extra: {}", destination);
       }
     }
     private void handleRunningTopic(String runningId, String userId) {


### PR DESCRIPTION
### 연관된 이슈를 적어주세요 📌

### 작업한 내용을 설명해주세요 ✔️

- sendToUser 메서드 작성
- aggregate의 경우 예외가 터졌을때 Connection을 끊지않고 재신청하도록 try-catch로 잡아서 메세지 발행
```
try {
      runningResultService.saveRunningResult(
              requestDto.getRunningId(), requestDto.getUserId(), requestDto.getDataList());
    } catch (Exception e) {
      sendToUser(sessionId, "/queue/logs", ErrorResponse.of(RunningErrorCode.AGGREGATE_FAILED));
      return;
    }

``` 

### 트러블 슈팅
- 정말 어이없지만 헤더에 세션값과 mutable옵션을 주니까 유니캐스트가 작동하는군요.

`StompSubProtocolErrorHandler` 클래스에서 커넥션 맺은 사람한테 단일 메세지 보내는 것을 확인해보니 아래와 같이 코드가 작성되어서
비슷한 로직으로 작성하니 작동했숨돠

```java
@Nullable
    public Message<byte[]> handleClientMessageProcessingError(@Nullable Message<byte[]> clientMessage, Throwable ex) {
        StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.ERROR);
        accessor.setMessage(ex.getMessage());
        accessor.setLeaveMutable(true);
        StompHeaderAccessor clientHeaderAccessor = null;
        if (clientMessage != null) {
            clientHeaderAccessor = (StompHeaderAccessor)MessageHeaderAccessor.getAccessor(clientMessage, StompHeaderAccessor.class);
            if (clientHeaderAccessor != null) {
                String receiptId = clientHeaderAccessor.getReceipt();
                if (receiptId != null) {
                    accessor.setReceiptId(receiptId);
                }
            }
        }
```

### 리뷰어에게 하고 싶은 말을 적어주세요
![Screenshot 2024-10-09 at 1 11 02 PM](https://github.com/user-attachments/assets/40aae747-5a88-4b46-9a37-235919c6eb90)
STOMP 표준에선 `ERROR` 메세지를 전송하면 커넥션을 끊어야한다고 합니다. 그래서 이번 커밋에서 작성한 것 처럼 에러 핸들링을
전역에서 처리하는 것이 아닌 컨트롤러 단에서 잡아서 `sendToUser`를 해줘야할 것 같아요

### 확인하기

- [x] : 코드에 에러가 없는지 확인했나요?
- [x] : PR에 설명을 기재했나요?
- [x] : PR 태그를 붙였나요?
- [x] : 불필요한 로그나 `System.out`을 제거했나요?