### PR TITLE
[Feature/save running record] - 개인 기록 저장 및 조회 개발

### DIFF
--- a/src/main/java/com/run_us/server/domains/running/controller/RunningController.java
+++ b/src/main/java/com/run_us/server/domains/running/controller/RunningController.java
@@ -42,7 +42,7 @@ public class RunningController {
    * @param userId 사용자 고유번호
    * */
   @GetMapping("/{runningId}/records/{userId}")
-  public SuccessResponse getPersonalRecord(@PathVariable String runningId, @PathVariable Long userId) {
+  public SuccessResponse getPersonalRecord(@PathVariable String runningId, @PathVariable String userId) {
     return SuccessResponse.of(ExampleErrorCode.SUCCESS,
         runningResultService.getPersonalRecord(runningId, userId));
   }

--- a/src/main/java/com/run_us/server/domains/running/controller/RunningController.java
+++ b/src/main/java/com/run_us/server/domains/running/controller/RunningController.java
@@ -2,6 +2,7 @@ package com.run_us.server.domains.running.controller;
 
 import com.run_us.server.domains.running.controller.model.request.RunningCreateRequest;
 import com.run_us.server.domains.running.service.RunningPreparationService;
+import com.run_us.server.domains.running.service.RunningResultService;
 import com.run_us.server.domains.running.service.model.JoinedParticipant;
 import com.run_us.server.global.common.SuccessResponse;
 import com.run_us.server.global.exception.code.ExampleErrorCode;
@@ -20,6 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class RunningController {
 
   private final RunningPreparationService runningPreparationService;
+  private final RunningResultService runningResultService;
 
   @PostMapping
   public SuccessResponse createRunning(@RequestBody RunningCreateRequest runningCreateDto) {
@@ -32,5 +34,16 @@ public class RunningController {
     List<JoinedParticipant> joinedParticipants = runningPreparationService.getJoinedParticipants(
         runningId);
     return SuccessResponse.of(ExampleErrorCode.SUCCESS, joinedParticipants);
+  }
+
+  /***
+   * 특정 러닝의 특정 사용자 기록을 조회하는 API
+   * @param runningId 러닝 고유번호
+   * @param userId 사용자 고유번호
+   * */
+  @GetMapping("/{runningId}/records/{userId}")
+  public SuccessResponse getPersonalRecord(@PathVariable String runningId, @PathVariable Long userId) {
+    return SuccessResponse.of(ExampleErrorCode.SUCCESS,
+        runningResultService.getPersonalRecord(runningId, userId));
   }
 }

--- a/src/main/java/com/run_us/server/domains/running/controller/RunningSocketController.java
+++ b/src/main/java/com/run_us/server/domains/running/controller/RunningSocketController.java
@@ -9,6 +9,7 @@ import com.run_us.server.domains.running.exception.RunningErrorCode;
 import com.run_us.server.domains.running.service.RunningLiveService;
 import com.run_us.server.domains.running.service.RunningPreparationService;
 import com.run_us.server.domains.running.service.RunningResultService;
+import com.run_us.server.domains.running.service.model.RunningMapper;
 import com.run_us.server.global.common.ErrorResponse;
 import com.run_us.server.global.common.SuccessResponse;
 import jakarta.validation.constraints.NotNull;
@@ -116,14 +117,12 @@ public class RunningSocketController {
   public void aggregateRunning(
           @Header("simpSessionId") String sessionId, RunningRequest.AggregateRunning requestDto) {
     try {
-      runningResultService.saveRunningResult(
-              requestDto.getRunningId(), requestDto.getUserId(), requestDto.getDataList());
+      runningResultService.savePersonalRecord(requestDto.getRunningId(), requestDto.getUserId(), RunningMapper.toRunningAggregation(requestDto));
     } catch (Exception e) {
       sendToUser(sessionId, "/queue/logs", ErrorResponse.of(RunningErrorCode.AGGREGATE_FAILED));
       return;
     }
-    sendToUser(
-            sessionId, "/queue/logs", SuccessResponse.messageOnly(RunningSocketResponseCode.END_RUNNING));
+    sendToUser(sessionId, "/queue/logs", SuccessResponse.messageOnly(RunningSocketResponseCode.END_RUNNING));
   }
 
   /***

--- a/src/main/java/com/run_us/server/domains/running/controller/model/request/RunningCreateRequest.java
+++ b/src/main/java/com/run_us/server/domains/running/controller/model/request/RunningCreateRequest.java
@@ -1,8 +1,8 @@
 package com.run_us.server.domains.running.controller.model.request;
 
 import com.run_us.server.domains.running.domain.LocationData.RunnerPos;
-import com.run_us.server.domains.running.domain.RunningConstraints;
-import com.run_us.server.domains.running.domain.RunningDescription;
+import com.run_us.server.domains.running.domain.running.RunningConstraints;
+import com.run_us.server.domains.running.domain.running.RunningDescription;
 import lombok.Getter;
 
 @Getter

--- a/src/main/java/com/run_us/server/domains/running/controller/model/request/RunningRequest.java
+++ b/src/main/java/com/run_us/server/domains/running/controller/model/request/RunningRequest.java
@@ -18,9 +18,6 @@ public class RunningRequest {
         private String runningId;
         private String runningKey;
 
-        // Websocket - start
-        // inner class의 효능
-        // 난잡한 디렉구조 해결
         @Builder
         public StartRunning(String userId, String runningId, String runningKey) {
             this.userId = userId;
@@ -105,14 +102,26 @@ public class RunningRequest {
         private final String userId;
         private final List<LocationData> dataList;
         private final int count;
+        private final int runningDistanceInMeter;
+        private final int runningDurationInMilliSecond;
+        private final int averagePaceInMilliSecond;
 
         @Builder
-        public AggregateRunning(final String runningId, final String userId, final int count, final List<LocationData> dataList) {
+        public AggregateRunning(
+                final String runningId,
+                final String userId,
+                final int count,
+                final List<LocationData> dataList,
+                final int runningDistanceInMeter,
+                final int runningDurationInMilliSecond,
+                final int averagePaceInMilliSecond) {
             this.runningId = runningId;
             this.userId = userId;
             this.count = count;
             this.dataList = dataList;
+            this.runningDistanceInMeter = runningDistanceInMeter;
+            this.runningDurationInMilliSecond = runningDurationInMilliSecond;
+            this.averagePaceInMilliSecond = averagePaceInMilliSecond;
         }
-
     }
 }

--- a/src/main/java/com/run_us/server/domains/running/controller/model/response/RunningCreateResponse.java
+++ b/src/main/java/com/run_us/server/domains/running/controller/model/response/RunningCreateResponse.java
@@ -1,6 +1,6 @@
 package com.run_us.server.domains.running.controller.model.response;
 
-import com.run_us.server.domains.running.domain.Running;
+import com.run_us.server.domains.running.domain.running.Running;
 import lombok.Getter;
 
 @Getter

--- a/src/main/java/com/run_us/server/domains/running/domain/LocationData.java
+++ b/src/main/java/com/run_us/server/domains/running/domain/LocationData.java
@@ -20,7 +20,6 @@ public class LocationData {
         return runnerPos.longitude;
     }
 
-    //TODO: sql에 사용되는 Point클래스와 이름이 겹친다. 추후 수정 필요
     @Getter
     public static class RunnerPos {
         private final double latitude;

--- a/src/main/java/com/run_us/server/domains/running/domain/LocationData.java
+++ b/src/main/java/com/run_us/server/domains/running/domain/LocationData.java
@@ -55,5 +55,10 @@ public class LocationData {
 
             return R * c;
         }
+
+        @Override
+        public String toString() {
+            return String.format("{%s, %s}", latitude, longitude);
+        }
     }
 }

--- a/src/main/java/com/run_us/server/domains/running/domain/RunningType.java
+++ b/src/main/java/com/run_us/server/domains/running/domain/RunningType.java
@@ -1,6 +1,0 @@
-package com.run_us.server.domains.running.domain;
-
-public enum RunningType {
-  SINGLE,
-  GROUP
-}

--- a/src/main/java/com/run_us/server/domains/running/domain/record/PersonalRecord.java
+++ b/src/main/java/com/run_us/server/domains/running/domain/record/PersonalRecord.java
@@ -1,4 +1,4 @@
-package com.run_us.server.domains.running.domain;
+package com.run_us.server.domains.running.domain.record;
 
 import com.run_us.server.global.common.DateAudit;
 import jakarta.persistence.Column;
@@ -36,14 +36,37 @@ public class PersonalRecord extends DateAudit {
   @Column(name = "record_data", nullable = false)
   private String recordData;
 
-  @Enumerated(EnumType.STRING)
-  private RunningType runningType;
+  @Column(name = "distance")
+  private Integer runningDistanceInMeters;
 
+  @Column(name = "duration")
+  private Integer runningDurationInMilliseconds;
+
+  @Column(name = "avg_pace")
+  private Integer averagePaceInMilliseconds;
+
+  /***
+   * 개인 기록 객체를 위한 생성자
+   * @param runningId 러닝 id
+   * @param userId 유저 id
+   * @param recordData 기록 데이터
+   * @param runningDistanceInMeters 러닝 거리(미터)
+   * @param averagePaceInMilliseconds 평균 페이스(밀리초)
+   * @param runningDurationInMilliseconds 러닝 시간(밀리초)
+   */
   @Builder
-  public PersonalRecord(Long runningId, Long userId, String recordData, RunningType runningType) {
+  public PersonalRecord(
+      Long runningId,
+      Long userId,
+      String recordData,
+      Integer runningDistanceInMeters,
+      Integer runningDurationInMilliseconds,
+      Integer averagePaceInMilliseconds) {
     this.runningId = runningId;
     this.userId = userId;
     this.recordData = recordData;
-    this.runningType = runningType;
+    this.runningDistanceInMeters = runningDistanceInMeters;
+    this.runningDurationInMilliseconds = runningDurationInMilliseconds;
+    this.averagePaceInMilliseconds = averagePaceInMilliseconds;
   }
 }

--- a/src/main/java/com/run_us/server/domains/running/domain/record/RunningRecord.java
+++ b/src/main/java/com/run_us/server/domains/running/domain/record/RunningRecord.java
@@ -1,4 +1,4 @@
-package com.run_us.server.domains.running.domain;
+package com.run_us.server.domains.running.domain.record;
 
 import com.run_us.server.global.common.DateAudit;
 import jakarta.persistence.Column;
@@ -39,7 +39,6 @@ public class RunningRecord extends DateAudit {
 
   @Column(name = "total_distance", nullable = false)
   private Double totalDistance;
-
 
   /***
    * Constructor for RunningRecord

--- a/src/main/java/com/run_us/server/domains/running/domain/record/RunningType.java
+++ b/src/main/java/com/run_us/server/domains/running/domain/record/RunningType.java
@@ -1,0 +1,6 @@
+package com.run_us.server.domains.running.domain.record;
+
+public enum RunningType {
+  SINGLE,
+  GROUP
+}

--- a/src/main/java/com/run_us/server/domains/running/domain/running/ParticipantStatus.java
+++ b/src/main/java/com/run_us/server/domains/running/domain/running/ParticipantStatus.java
@@ -1,4 +1,4 @@
-package com.run_us.server.domains.running.domain;
+package com.run_us.server.domains.running.domain.running;
 
 public enum ParticipantStatus {
     READY,

--- a/src/main/java/com/run_us/server/domains/running/domain/running/Participants.java
+++ b/src/main/java/com/run_us/server/domains/running/domain/running/Participants.java
@@ -1,4 +1,4 @@
-package com.run_us.server.domains.running.domain;
+package com.run_us.server.domains.running.domain.running;
 
 import jakarta.persistence.CollectionTable;
 import jakarta.persistence.ElementCollection;

--- a/src/main/java/com/run_us/server/domains/running/domain/running/Running.java
+++ b/src/main/java/com/run_us/server/domains/running/domain/running/Running.java
@@ -1,7 +1,7 @@
-package com.run_us.server.domains.running.domain;
+package com.run_us.server.domains.running.domain.running;
 
-import com.run_us.server.domains.running.domain.RunningConstraints.RunningConstraintsConverter;
-import com.run_us.server.domains.running.domain.RunningDescription.RunningDescriptionConverter;
+import com.run_us.server.domains.running.domain.running.RunningConstraints.RunningConstraintsConverter;
+import com.run_us.server.domains.running.domain.running.RunningDescription.RunningDescriptionConverter;
 import com.run_us.server.domains.user.domain.User;
 import com.run_us.server.global.common.DateAudit;
 import com.run_us.server.global.util.PassCodeGenerator;

--- a/src/main/java/com/run_us/server/domains/running/domain/running/RunningConstraints.java
+++ b/src/main/java/com/run_us/server/domains/running/domain/running/RunningConstraints.java
@@ -1,4 +1,4 @@
-package com.run_us.server.domains.running.domain;
+package com.run_us.server.domains.running.domain.running;
 
 import com.run_us.server.global.util.JsonConverter;
 import java.util.Objects;

--- a/src/main/java/com/run_us/server/domains/running/domain/running/RunningDescription.java
+++ b/src/main/java/com/run_us/server/domains/running/domain/running/RunningDescription.java
@@ -1,4 +1,4 @@
-package com.run_us.server.domains.running.domain;
+package com.run_us.server.domains.running.domain.running;
 
 import com.run_us.server.global.util.JsonConverter;
 import java.util.Objects;

--- a/src/main/java/com/run_us/server/domains/running/exception/RunningErrorCode.java
+++ b/src/main/java/com/run_us/server/domains/running/exception/RunningErrorCode.java
@@ -7,7 +7,8 @@ public enum RunningErrorCode implements CustomResponseCode {
 
   RUNNING_NOT_FOUND("RE001", "Running not found", "Running not found", HttpStatus.NOT_FOUND),
   AGGREGATE_FAILED("RE4001", "Failed to Save Running Result", "Failed to Save Running Result",
-      HttpStatus.BAD_REQUEST),;
+      HttpStatus.BAD_REQUEST),
+  PERSONAL_RECORD_NOT_FOUND("REH4001", "Personal Record not found", "Personal Record not found", HttpStatus.BAD_REQUEST);
 
 
   private final String code;

--- a/src/main/java/com/run_us/server/domains/running/repository/PersonalRecordRepository.java
+++ b/src/main/java/com/run_us/server/domains/running/repository/PersonalRecordRepository.java
@@ -1,8 +1,14 @@
 package com.run_us.server.domains.running.repository;
 
-import com.run_us.server.domains.running.domain.PersonalRecord;
+import com.run_us.server.domains.running.domain.record.PersonalRecord;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
 
 public interface PersonalRecordRepository extends JpaRepository<PersonalRecord, Long> {
 
+    Optional<PersonalRecord> findByUserIdAndRunningId(Long userId, Long runningId);
+
+    List<PersonalRecord> findAllByUserId(Long userId);
 }

--- a/src/main/java/com/run_us/server/domains/running/repository/PersonalRecordRepository.java
+++ b/src/main/java/com/run_us/server/domains/running/repository/PersonalRecordRepository.java
@@ -1,14 +1,30 @@
 package com.run_us.server.domains.running.repository;
 
 import com.run_us.server.domains.running.domain.record.PersonalRecord;
+import com.run_us.server.domains.running.service.model.PersonalRecordQueryResult;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface PersonalRecordRepository extends JpaRepository<PersonalRecord, Long> {
 
-    Optional<PersonalRecord> findByUserIdAndRunningId(Long userId, Long runningId);
+    @Query("SELECT new com.run_us.server.domains.running.service.model.PersonalRecordQueryResult(" +
+            "p.runningDistanceInMeters, " +
+            "p.runningDurationInMilliseconds, " +
+            "p.averagePaceInMilliseconds, " +
+            "p.createdAt) " +
+            "FROM PersonalRecord p " +
+            "WHERE p.userId = :userId AND p.runningId = :runningId")
+    Optional<PersonalRecordQueryResult> findByUserIdAndRunningId(Long userId, Long runningId);
 
-    List<PersonalRecord> findAllByUserId(Long userId);
+    @Query("SELECT new com.run_us.server.domains.running.service.model.PersonalRecordQueryResult(" +
+            "p.runningDistanceInMeters, " +
+            "p.runningDurationInMilliseconds, " +
+            "p.averagePaceInMilliseconds, " +
+            "p.createdAt) " +
+            "FROM PersonalRecord p " +
+            "WHERE p.userId = :userId")
+    List<PersonalRecordQueryResult> findAllByUserId(Long userId);
 }

--- a/src/main/java/com/run_us/server/domains/running/repository/RunningRedisRepository.java
+++ b/src/main/java/com/run_us/server/domains/running/repository/RunningRedisRepository.java
@@ -6,7 +6,7 @@ import static com.run_us.server.domains.running.service.util.RunningKeyUtil.extr
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.run_us.server.domains.running.domain.LocationData;
 import com.run_us.server.domains.running.domain.LocationData.RunnerPos;
-import com.run_us.server.domains.running.domain.ParticipantStatus;
+import com.run_us.server.domains.running.domain.running.ParticipantStatus;
 import com.run_us.server.domains.running.domain.RunningConst;
 import java.util.HashMap;
 import java.util.HashSet;

--- a/src/main/java/com/run_us/server/domains/running/repository/RunningRepository.java
+++ b/src/main/java/com/run_us/server/domains/running/repository/RunningRepository.java
@@ -1,6 +1,6 @@
 package com.run_us.server.domains.running.repository;
 
-import com.run_us.server.domains.running.domain.Running;
+import com.run_us.server.domains.running.domain.running.Running;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;

--- a/src/main/java/com/run_us/server/domains/running/service/RunningLiveService.java
+++ b/src/main/java/com/run_us/server/domains/running/service/RunningLiveService.java
@@ -4,8 +4,8 @@ import static com.run_us.server.domains.running.domain.RunningConst.RUNNING_PREF
 import static com.run_us.server.domains.running.service.util.RunningKeyUtil.createLiveKey;
 
 import com.run_us.server.domains.running.domain.LocationData.RunnerPos;
-import com.run_us.server.domains.running.domain.ParticipantStatus;
-import com.run_us.server.domains.running.domain.Running;
+import com.run_us.server.domains.running.domain.running.ParticipantStatus;
+import com.run_us.server.domains.running.domain.running.Running;
 import com.run_us.server.domains.running.domain.RunningConst;
 import com.run_us.server.domains.running.exception.RunningErrorCode;
 import com.run_us.server.domains.running.exception.RunningException;

--- a/src/main/java/com/run_us/server/domains/running/service/RunningPreparationService.java
+++ b/src/main/java/com/run_us/server/domains/running/service/RunningPreparationService.java
@@ -3,7 +3,7 @@ package com.run_us.server.domains.running.service;
 import com.run_us.server.domains.running.service.model.JoinedParticipant;
 import com.run_us.server.domains.running.controller.model.request.RunningCreateRequest;
 import com.run_us.server.domains.running.controller.model.response.RunningCreateResponse;
-import com.run_us.server.domains.running.domain.Running;
+import com.run_us.server.domains.running.domain.running.Running;
 import com.run_us.server.domains.running.exception.RunningErrorCode;
 import com.run_us.server.domains.running.exception.RunningException;
 import com.run_us.server.domains.running.repository.RunningRepository;

--- a/src/main/java/com/run_us/server/domains/running/service/RunningResultService.java
+++ b/src/main/java/com/run_us/server/domains/running/service/RunningResultService.java
@@ -6,6 +6,7 @@ import com.run_us.server.domains.running.exception.RunningErrorCode;
 import com.run_us.server.domains.running.exception.RunningException;
 import com.run_us.server.domains.running.repository.PersonalRecordRepository;
 import com.run_us.server.domains.running.repository.RunningRepository;
+import com.run_us.server.domains.running.service.model.PersonalRecordQueryResult;
 import com.run_us.server.domains.running.service.model.RunningAggregation;
 import com.run_us.server.domains.running.service.model.RunningMapper;
 import com.run_us.server.domains.user.domain.User;
@@ -49,7 +50,7 @@ public class RunningResultService {
      * @param runningId 러닝 고유번호
      * @return 러닝 결과
      */
-    public PersonalRecord getPersonalRecord(String runningId, String userId) {
+    public PersonalRecordQueryResult getPersonalRecord(String runningId, String userId) {
       Running running = runningRepository.findByPublicKey(runningId)
               .orElseThrow(() -> RunningException.of(RunningErrorCode.RUNNING_NOT_FOUND));
 
@@ -65,7 +66,7 @@ public class RunningResultService {
      * @param userId 유저 고유번호
      * @return 개인 기록 리스트
      */
-    public List<PersonalRecord> getAllPersonalRecords(Long userId) {
+    public List<PersonalRecordQueryResult> getAllPersonalRecords(Long userId) {
       return personalRecordRepository.findAllByUserId(userId);
     }
 }

--- a/src/main/java/com/run_us/server/domains/running/service/RunningResultService.java
+++ b/src/main/java/com/run_us/server/domains/running/service/RunningResultService.java
@@ -49,10 +49,14 @@ public class RunningResultService {
      * @param runningId 러닝 고유번호
      * @return 러닝 결과
      */
-    public PersonalRecord getPersonalRecord(String runningId, Long userId) {
+    public PersonalRecord getPersonalRecord(String runningId, String userId) {
       Running running = runningRepository.findByPublicKey(runningId)
               .orElseThrow(() -> RunningException.of(RunningErrorCode.RUNNING_NOT_FOUND));
-      return personalRecordRepository.findByUserIdAndRunningId(userId, running.getId())
+
+      User user = userRepository.findByPublicId(userId)
+              .orElseThrow(IllegalArgumentException::new);
+
+      return personalRecordRepository.findByUserIdAndRunningId(user.getId(), running.getId())
                 .orElseThrow(() -> RunningException.of(RunningErrorCode.PERSONAL_RECORD_NOT_FOUND));
     }
 

--- a/src/main/java/com/run_us/server/domains/running/service/RunningResultService.java
+++ b/src/main/java/com/run_us/server/domains/running/service/RunningResultService.java
@@ -1,20 +1,21 @@
 package com.run_us.server.domains.running.service;
 
-import com.run_us.server.domains.running.domain.LocationData;
-import com.run_us.server.domains.running.domain.PersonalRecord;
-import com.run_us.server.domains.running.domain.Running;
-import com.run_us.server.domains.running.domain.RunningType;
+import com.run_us.server.domains.running.domain.record.PersonalRecord;
+import com.run_us.server.domains.running.domain.running.Running;
 import com.run_us.server.domains.running.exception.RunningErrorCode;
 import com.run_us.server.domains.running.exception.RunningException;
 import com.run_us.server.domains.running.repository.PersonalRecordRepository;
 import com.run_us.server.domains.running.repository.RunningRepository;
+import com.run_us.server.domains.running.service.model.RunningAggregation;
+import com.run_us.server.domains.running.service.model.RunningMapper;
 import com.run_us.server.domains.user.domain.User;
 import com.run_us.server.domains.user.repository.UserRepository;
 import jakarta.transaction.Transactional;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Slf4j
 @Service
@@ -26,22 +27,41 @@ public class RunningResultService {
   private final UserRepository userRepository;
 
   /***
-   * 러닝 결과 저장
-   * @param runningId 러닝 키
-   * @param userId 유저 아이디
-   * @param locationUpdates locationUpdates 위치 정보 리스트
+   * 러닝 개인 기록 저장
+   * @param runningId 러닝 고유번호(public)
+   * @param userId 유저 고유번호(public)
+   * @param aggregation 러닝 데이터 결과
    */
   @Transactional
-  public void saveRunningResult(String runningId, String userId, List<LocationData> locationUpdates) {
+  public void savePersonalRecord(String runningId, String userId, RunningAggregation aggregation) {
     Running running = runningRepository.findByPublicKey(runningId)
         .orElseThrow(() -> RunningException.of(RunningErrorCode.RUNNING_NOT_FOUND));
-    User user = userRepository.findByPublicId(userId).orElseThrow(IllegalArgumentException::new);
-    PersonalRecord personalRecord = PersonalRecord.builder()
-        .runningId(running.getId())
-        .userId(user.getId())
-        .runningType(RunningType.SINGLE)
-        .recordData(locationUpdates.stream().toString())
-        .build();
+
+    User user = userRepository.findByPublicId(userId)
+            .orElseThrow(IllegalArgumentException::new);
+
+    PersonalRecord personalRecord = RunningMapper.toPersonalRecord(running.getId(), user.getId(), aggregation);
     personalRecordRepository.save(personalRecord);
   }
+
+    /***
+     * 러닝 개인 기록
+     * @param runningId 러닝 고유번호
+     * @return 러닝 결과
+     */
+    public PersonalRecord getPersonalRecord(String runningId, Long userId) {
+      Running running = runningRepository.findByPublicKey(runningId)
+              .orElseThrow(() -> RunningException.of(RunningErrorCode.RUNNING_NOT_FOUND));
+      return personalRecordRepository.findByUserIdAndRunningId(userId, running.getId())
+                .orElseThrow(() -> RunningException.of(RunningErrorCode.PERSONAL_RECORD_NOT_FOUND));
+    }
+
+    /***
+     * 유저의 모든 개인 기록 조회
+     * @param userId 유저 고유번호
+     * @return 개인 기록 리스트
+     */
+    public List<PersonalRecord> getAllPersonalRecords(Long userId) {
+      return personalRecordRepository.findAllByUserId(userId);
+    }
 }

--- a/src/main/java/com/run_us/server/domains/running/service/model/PersonalRecordQueryResult.java
+++ b/src/main/java/com/run_us/server/domains/running/service/model/PersonalRecordQueryResult.java
@@ -1,0 +1,28 @@
+package com.run_us.server.domains.running.service.model;
+
+import lombok.Getter;
+
+import java.time.Duration;
+import java.time.ZonedDateTime;
+import java.util.concurrent.TimeUnit;
+
+@Getter
+public class PersonalRecordQueryResult {
+    private final Integer runningDistanceInMeters;
+
+    private final Integer runningDurationInMilliseconds;
+
+    private final Integer averagePaceInMilliseconds;
+
+    private final ZonedDateTime startedAt;
+
+    public PersonalRecordQueryResult(Integer runningDistanceInMeters,
+                                     Integer runningDurationInMilliseconds,
+                                     Integer averagePaceInMilliseconds,
+                                     ZonedDateTime createdAt) {
+        this.runningDistanceInMeters = runningDistanceInMeters;
+        this.runningDurationInMilliseconds = runningDurationInMilliseconds;
+        this.averagePaceInMilliseconds = averagePaceInMilliseconds;
+        this.startedAt = createdAt.minus(Duration.of(averagePaceInMilliseconds, TimeUnit.MILLISECONDS.toChronoUnit()));
+    }
+}

--- a/src/main/java/com/run_us/server/domains/running/service/model/RunningAggregation.java
+++ b/src/main/java/com/run_us/server/domains/running/service/model/RunningAggregation.java
@@ -1,0 +1,29 @@
+package com.run_us.server.domains.running.service.model;
+
+import com.run_us.server.domains.running.domain.LocationData;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class RunningAggregation {
+    private final String runningId;
+    private final String userId;
+    private final List<LocationData> dataList;
+    private final int count;
+    private final int runningDistanceInMeter;
+    private final int runningDurationInMilliSecond;
+    private final int averagePaceInMilliSecond;
+
+    @Builder
+    public RunningAggregation(String runningId, String userId, List<LocationData> dataList, int count, int runningDistanceInMeter, int runningDurationInMilliSecond, int averagePaceInMilliSecond) {
+        this.runningId = runningId;
+        this.userId = userId;
+        this.dataList = dataList;
+        this.count = count;
+        this.runningDistanceInMeter = runningDistanceInMeter;
+        this.runningDurationInMilliSecond = runningDurationInMilliSecond;
+        this.averagePaceInMilliSecond = averagePaceInMilliSecond;
+    }
+}

--- a/src/main/java/com/run_us/server/domains/running/service/model/RunningAggregation.java
+++ b/src/main/java/com/run_us/server/domains/running/service/model/RunningAggregation.java
@@ -17,7 +17,14 @@ public class RunningAggregation {
     private final int averagePaceInMilliSecond;
 
     @Builder
-    public RunningAggregation(String runningId, String userId, List<LocationData> dataList, int count, int runningDistanceInMeter, int runningDurationInMilliSecond, int averagePaceInMilliSecond) {
+    public RunningAggregation(
+            final String runningId,
+            final String userId,
+            final List<LocationData> dataList,
+            final int count,
+            final int runningDistanceInMeter,
+            final int runningDurationInMilliSecond,
+            final int averagePaceInMilliSecond) {
         this.runningId = runningId;
         this.userId = userId;
         this.dataList = dataList;

--- a/src/main/java/com/run_us/server/domains/running/service/model/RunningMapper.java
+++ b/src/main/java/com/run_us/server/domains/running/service/model/RunningMapper.java
@@ -5,6 +5,8 @@ import com.run_us.server.domains.running.domain.record.PersonalRecord;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
+import java.util.stream.Collectors;
+
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class RunningMapper {
 
@@ -32,7 +34,7 @@ public final class RunningMapper {
     return PersonalRecord.builder()
         .runningId(runningId)
         .userId(userId)
-        .recordData(aggregateRunning.getDataList().stream().toString())
+        .recordData(aggregateRunning.getDataList().stream().map(e->e.getRunnerPos().toString()).collect(Collectors.joining(",")))
         .runningDistanceInMeters(aggregateRunning.getRunningDistanceInMeter())
         .runningDurationInMilliseconds(aggregateRunning.getRunningDurationInMilliSecond())
         .averagePaceInMilliseconds(aggregateRunning.getAveragePaceInMilliSecond())

--- a/src/main/java/com/run_us/server/domains/running/service/model/RunningMapper.java
+++ b/src/main/java/com/run_us/server/domains/running/service/model/RunningMapper.java
@@ -1,0 +1,38 @@
+package com.run_us.server.domains.running.service.model;
+
+import com.run_us.server.domains.running.controller.model.request.RunningRequest;
+import com.run_us.server.domains.running.domain.record.PersonalRecord;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class RunningMapper {
+
+  public static RunningAggregation toRunningAggregation(RunningRequest.AggregateRunning aggregateRunning) {
+    return RunningAggregation.builder()
+        .dataList(aggregateRunning.getDataList())
+        .count(aggregateRunning.getCount())
+        .runningDistanceInMeter(aggregateRunning.getRunningDistanceInMeter())
+        .runningDurationInMilliSecond(aggregateRunning.getRunningDurationInMilliSecond())
+        .averagePaceInMilliSecond(aggregateRunning.getAveragePaceInMilliSecond())
+        .build();
+  }
+
+  /***
+   * 개인기록 도메일 객체로 매핑하는 메서드
+   *
+   * @param userId 유저 id
+   * @param runningId 러닝 id
+   * @param aggregateRunning 러닝결과 집계
+   */
+  public static PersonalRecord toPersonalRecord(Long userId, Long runningId, RunningAggregation aggregateRunning) {
+    return PersonalRecord.builder()
+        .runningId(runningId)
+        .userId(userId)
+        .recordData(aggregateRunning.getDataList().stream().toString())
+        .runningDistanceInMeters(aggregateRunning.getRunningDistanceInMeter())
+        .runningDurationInMilliseconds(aggregateRunning.getRunningDurationInMilliSecond())
+        .averagePaceInMilliseconds(aggregateRunning.getAveragePaceInMilliSecond())
+        .build();
+  }
+}

--- a/src/main/java/com/run_us/server/domains/running/service/model/RunningMapper.java
+++ b/src/main/java/com/run_us/server/domains/running/service/model/RunningMapper.java
@@ -19,13 +19,16 @@ public final class RunningMapper {
   }
 
   /***
-   * 개인기록 도메일 객체로 매핑하는 메서드
+   * 개인기록 도메인 객체로 매핑하는 메서드
    *
    * @param userId 유저 id
    * @param runningId 러닝 id
    * @param aggregateRunning 러닝결과 집계
    */
-  public static PersonalRecord toPersonalRecord(Long userId, Long runningId, RunningAggregation aggregateRunning) {
+  public static PersonalRecord toPersonalRecord(
+          final Long userId,
+          final Long runningId,
+          final RunningAggregation aggregateRunning) {
     return PersonalRecord.builder()
         .runningId(runningId)
         .userId(userId)

--- a/src/test/java/com/run_us/server/domains/running/PersonalRecordFixtures.java
+++ b/src/test/java/com/run_us/server/domains/running/PersonalRecordFixtures.java
@@ -1,0 +1,18 @@
+package com.run_us.server.domains.running;
+
+import com.run_us.server.domains.running.domain.record.PersonalRecord;
+
+public final class PersonalRecordFixtures {
+
+    public static PersonalRecord getPersonalRecordWithUserIdAndRunningId(Long userId, Long runningId) {
+        return PersonalRecord.builder()
+            .runningId(userId)
+            .userId(runningId)
+            .recordData("recordData")
+            .runningDistanceInMeters(1000)
+            .runningDurationInMilliseconds(1000)
+            .averagePaceInMilliseconds(1000)
+            .build();
+    }
+
+}

--- a/src/test/java/com/run_us/server/domains/running/RunningControllerTest.java
+++ b/src/test/java/com/run_us/server/domains/running/RunningControllerTest.java
@@ -3,7 +3,7 @@ package com.run_us.server.domains.running;
 import com.run_us.server.config.TestRedisConfiguration;
 import com.run_us.server.domains.running.service.model.JoinedParticipant;
 import com.run_us.server.domains.running.controller.RunningController;
-import com.run_us.server.domains.running.domain.Running;
+import com.run_us.server.domains.running.domain.running.Running;
 import com.run_us.server.domains.running.repository.RunningRepository;
 import com.run_us.server.domains.user.domain.User;
 import com.run_us.server.domains.user.domain.UserFixtures;

--- a/src/test/java/com/run_us/server/domains/running/RunningControllerTest.java
+++ b/src/test/java/com/run_us/server/domains/running/RunningControllerTest.java
@@ -7,6 +7,7 @@ import com.run_us.server.domains.running.service.model.JoinedParticipant;
 import com.run_us.server.domains.running.controller.RunningController;
 import com.run_us.server.domains.running.domain.running.Running;
 import com.run_us.server.domains.running.repository.RunningRepository;
+import com.run_us.server.domains.running.service.model.PersonalRecordQueryResult;
 import com.run_us.server.domains.user.domain.User;
 import com.run_us.server.domains.user.domain.UserFixtures;
 import com.run_us.server.domains.user.repository.UserRepository;
@@ -100,7 +101,7 @@ class RunningControllerTest {
           String userId = u1.getPublicId();
           // when
           SuccessResponse successResponse = runningController.getPersonalRecord(runningId, userId);
-          PersonalRecord personalRecord = (PersonalRecord) successResponse.getPayload();
+          PersonalRecordQueryResult personalRecord = (PersonalRecordQueryResult) successResponse.getPayload();
           //then
           Assertions.assertNotNull(successResponse.getPayload());
           Assertions.assertEquals(personalRecord.getAveragePaceInMilliseconds(), 1000);

--- a/src/test/java/com/run_us/server/domains/running/RunningControllerTest.java
+++ b/src/test/java/com/run_us/server/domains/running/RunningControllerTest.java
@@ -97,7 +97,7 @@ class RunningControllerTest {
         void it_returns_personal_record() {
           // given
           String runningId = r1.getPublicKey();
-          Long userId = u1.getId();
+          String userId = u1.getPublicId();
           // when
           SuccessResponse successResponse = runningController.getPersonalRecord(runningId, userId);
           PersonalRecord personalRecord = (PersonalRecord) successResponse.getPayload();

--- a/src/test/java/com/run_us/server/domains/running/RunningFixtures.java
+++ b/src/test/java/com/run_us/server/domains/running/RunningFixtures.java
@@ -1,8 +1,8 @@
 package com.run_us.server.domains.running;
 
-import com.run_us.server.domains.running.domain.Running;
-import com.run_us.server.domains.running.domain.RunningConstraints;
-import com.run_us.server.domains.running.domain.RunningDescription;
+import com.run_us.server.domains.running.domain.running.Running;
+import com.run_us.server.domains.running.domain.running.RunningConstraints;
+import com.run_us.server.domains.running.domain.running.RunningDescription;
 import com.run_us.server.domains.user.domain.User;
 import com.run_us.server.global.util.PointGenerator;
 import java.util.List;

--- a/src/test/java/com/run_us/server/domains/running/RunningRedisRepositoryTest.java
+++ b/src/test/java/com/run_us/server/domains/running/RunningRedisRepositoryTest.java
@@ -1,7 +1,7 @@
 package com.run_us.server.domains.running;
 
 import com.run_us.server.config.TestRedisConfiguration;
-import com.run_us.server.domains.running.domain.ParticipantStatus;
+import com.run_us.server.domains.running.domain.running.ParticipantStatus;
 import com.run_us.server.domains.running.repository.RunningRedisRepository;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;

--- a/src/test/java/com/run_us/server/domains/running/RunningTest.java
+++ b/src/test/java/com/run_us/server/domains/running/RunningTest.java
@@ -2,9 +2,9 @@ package com.run_us.server.domains.running;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import com.run_us.server.domains.running.domain.Running;
-import com.run_us.server.domains.running.domain.RunningConstraints;
-import com.run_us.server.domains.running.domain.RunningDescription;
+import com.run_us.server.domains.running.domain.running.Running;
+import com.run_us.server.domains.running.domain.running.RunningConstraints;
+import com.run_us.server.domains.running.domain.running.RunningDescription;
 import com.run_us.server.domains.user.domain.User;
 import com.run_us.server.domains.user.domain.UserFixtures;
 import com.run_us.server.global.util.PointGenerator;


### PR DESCRIPTION
### 연관된 이슈를 적어주세요 📌
#32

### 작업한 내용을 설명해주세요 ✔️

- **달리기 개인 기록 조회 기능 개발**
  - 사용자 id와 러닝 id를 이용하여 조회
- **도메인 폴더 디렉토리 재구성**
  - `running`, `record` 디렉토리 생성
  - `record` 객체들은 id를 통한 간접참조를 하기 때문에 다른 디렉토리에 두어도 문제가 되지않는다고 생각했어요.
- **매퍼 클래스 작성**
  - 빌더를 응용서비스계층의 주요 로직에 두는 것보다 매핑하는 클래스를 두어 책임을 분리했어요 
- **테스트 코드 작성**
  - 컨트롤러 테스트 작성   

### 트러블 슈팅
### 리뷰어에게 하고 싶은 말을 적어주세요
- 서비스의 크기가 계속 커질 것 같아서 여러가지를 시도해봤다가 되돌리고 고민을 했네요..
![Screenshot 2024-10-15 at 12 51 10 AM](https://github.com/user-attachments/assets/59f9e01f-cf81-4391-bf67-5d39b5d4fd73)

- 첫번째 시도는 **유즈케이스마다 클래스를 쪼개고** 유즈케이스에서 requestdto를 받아서 매핑 처리를 하고 서비스에게 넘기는 형식이었습니다.
  - 표현계층으로부터의 의존(매핑을 포함)을 끊어내고 싶었어요. 
  - 너무 클래스가 많아지는 것 같고, 컨트롤러에 많은 유즈케이스 코드가 생성 코드가 생김
- 두번째 시도는 **그냥 DIP를 통한 디커플링**을 하자는 것이었습니다.
  - 지금이랑 크게 다른 것은 없고 인터페이스를 추가해서 의존을 끊어내는 방식이었어요.
  - 매퍼는 컨트롤러에서 담당하게 했어요. 여기에서 request dto가 도메인의 모델에 의존하게됩니다.
- 셋 그냥 지금처럼 가자!
  - 두번째랑 인터페이스 추가안한것만 다른것 같네요
![Screenshot 2024-10-15 at 1 03 54 AM](https://github.com/user-attachments/assets/da178e9e-2356-455b-8914-bfbdbffb91eb)
- facade나 usecase가 service레이어라고 치면 컨트롤러는 정말 request를 처리하고 반환만 할 수 있을 것 같아서 여러 시도를 해봤었네요



### 확인하기

- [x] : 코드에 에러가 없는지 확인했나요?
- [x] : PR에 설명을 기재했나요?
- [x] : PR 태그를 붙였나요?
- [x] : 불필요한 로그나 `System.out`을 제거했나요?