### PR TITLE
[Feat/socket handler] 소켓 에러 핸들리 - 기존 핸들러 수정, Controller 단 핸들러 추가 구현

### DIFF
--- a/src/main/java/com/run_us/server/domains/test/TestController.java
+++ b/src/main/java/com/run_us/server/domains/test/TestController.java
@@ -1,7 +1,10 @@
 package com.run_us.server.domains.test;
 
+import com.run_us.server.domains.running.exception.RunningErrorCode;
+import com.run_us.server.domains.running.exception.RunningException;
 import com.run_us.server.domains.user.domain.User;
 import com.run_us.server.global.common.SuccessResponse;
+import com.run_us.server.global.exception.BusinessException;
 import com.run_us.server.global.exception.code.ExampleErrorCode;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.handler.annotation.MessageMapping;
@@ -49,6 +52,18 @@ public class TestController {
 
 
     /**
-     * SendToUser 테스트 요청 만들기
+     * BusinessException 에러 소켓에서 내는 요청
      */
+    @MessageMapping("/test/errors/0")
+    public void occurBusinessException() {
+        throw BusinessException.of(ExampleErrorCode.EXAMPLE);
+    }
+
+    /**
+     * 소켓 RunningException 에러 소켓에서 내는 요청
+     */
+    @MessageMapping("/test/errors/1")
+    public void occurRunningException() {
+        throw RunningException.of(RunningErrorCode.RUNNING_NOT_FOUND);
+    }
 }

--- a/src/main/java/com/run_us/server/domains/test/TestController.java
+++ b/src/main/java/com/run_us/server/domains/test/TestController.java
@@ -56,6 +56,7 @@ public class TestController {
      */
     @MessageMapping("/test/errors/0")
     public void occurBusinessException() {
+        log.info("occurBusinessException : /test/errors/0");
         throw BusinessException.of(ExampleErrorCode.EXAMPLE);
     }
 
@@ -64,6 +65,7 @@ public class TestController {
      */
     @MessageMapping("/test/errors/1")
     public void occurRunningException() {
+        log.info("occurRunningException : /test/errors/1");
         throw RunningException.of(RunningErrorCode.RUNNING_NOT_FOUND);
     }
 }

--- a/src/main/java/com/run_us/server/global/common/SocketConst.java
+++ b/src/main/java/com/run_us/server/global/common/SocketConst.java
@@ -13,4 +13,6 @@ public final class SocketConst {
   public static final String USER_WS_SUBSCRIBE_PATH = "queue";
 
   public static final String USER_WS_ERROR_SUBSCRIBE_PATH = "/queue/errors";
+
+  public static final String WS_SESSION_ID_HEADER = "simpSessionId";
 }

--- a/src/main/java/com/run_us/server/global/common/SocketConst.java
+++ b/src/main/java/com/run_us/server/global/common/SocketConst.java
@@ -11,4 +11,6 @@ public final class SocketConst {
   public static final String WS_DESTINATION_PREFIX_QUEUE = "/queue";
 
   public static final String USER_WS_SUBSCRIBE_PATH = "queue";
+
+  public static final String USER_WS_ERROR_SUBSCRIBE_PATH = "/queue/errors";
 }

--- a/src/main/java/com/run_us/server/global/exception/GlobalSocketExceptionHandler.java
+++ b/src/main/java/com/run_us/server/global/exception/GlobalSocketExceptionHandler.java
@@ -1,0 +1,44 @@
+package com.run_us.server.global.exception;
+
+import com.run_us.server.global.common.ErrorResponse;
+import jakarta.validation.constraints.NotNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.messaging.handler.annotation.MessageExceptionHandler;
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
+import org.springframework.messaging.simp.SimpMessageType;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import static com.run_us.server.global.common.SocketConst.USER_WS_ERROR_SUBSCRIBE_PATH;
+import static com.run_us.server.global.common.SocketConst.WS_SESSION_ID_HEADER;
+
+/**
+ * 소켓 컨트롤러 이후 단에서 발생하는 에러 핸들러
+ */
+@Slf4j
+@RequiredArgsConstructor
+@ControllerAdvice
+public class GlobalSocketExceptionHandler extends ResponseEntityExceptionHandler {
+
+    private final SimpMessagingTemplate simpMessagingTemplate;
+
+    @MessageExceptionHandler(BusinessException.class)
+    public void handleBusinessException(BusinessException e, @Header(WS_SESSION_ID_HEADER) String sessionId) {
+        log.info("[ExceptionHandler] catch BusinessException");
+        sendToUser(sessionId, USER_WS_ERROR_SUBSCRIBE_PATH, ErrorResponse.of(e.getErrorCode()));
+    }
+
+    // TODO : 중복 로직
+    private void sendToUser(@NotNull String sessionId, @NotNull String destination, Object payload) {
+        SimpMessageHeaderAccessor headerAccessor =
+                SimpMessageHeaderAccessor.create(SimpMessageType.MESSAGE);
+        headerAccessor.setSessionId(sessionId);
+        headerAccessor.setLeaveMutable(true);
+        simpMessagingTemplate.convertAndSendToUser(
+                sessionId, destination, payload, headerAccessor.getMessageHeaders());
+    }
+
+}

--- a/src/main/java/com/run_us/server/global/exception/SocketBusinessExceptionHandler.java
+++ b/src/main/java/com/run_us/server/global/exception/SocketBusinessExceptionHandler.java
@@ -1,0 +1,44 @@
+package com.run_us.server.global.exception;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.run_us.server.global.common.ErrorResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class SocketBusinessExceptionHandler implements SocketExceptionCustomHandler {
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public boolean canHandle(Throwable e) {
+        return e instanceof BusinessException;
+    }
+
+    @Override
+    public Message<byte[]> handle(Message<byte[]> clientMessage, Throwable e) {
+        log.info("[StompErrorHandler] BusinessException");
+        return createErrorMessage((BusinessException) e);
+    }
+
+    private Message<byte[]> createErrorMessage(BusinessException e) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.MESSAGE);
+        String errorBody = "";
+        try {
+            errorBody = objectMapper.writeValueAsString(ErrorResponse.of(e.getErrorCode()));
+        }
+        catch (JsonProcessingException jsonProcessingException) {
+            log.info("[StompErrorHandler] exception cannot convert to json");
+        }
+        return MessageBuilder.createMessage(errorBody.getBytes(StandardCharsets.UTF_8), accessor.getMessageHeaders());
+    }
+}

--- a/src/main/java/com/run_us/server/global/exception/SocketExceptionCustomHandler.java
+++ b/src/main/java/com/run_us/server/global/exception/SocketExceptionCustomHandler.java
@@ -1,0 +1,23 @@
+package com.run_us.server.global.exception;
+
+import org.springframework.lang.Nullable;
+import org.springframework.messaging.Message;
+
+public interface SocketExceptionCustomHandler {
+    /**
+     * 해당 핸들러가 처리할 수 있는 예외인지 반환
+     * @param e : 확인할 예외
+     * @return 해당 ㅇ외 처리 가능여부
+     */
+    boolean canHandle(Throwable e);
+
+    /**
+     * 예외 처리 메서드
+     * @param clientMessage : 클라이언트가 보낸 메세지
+     * @param e : 처리할 예외
+     * @return 클라이언트에 전달할 응답
+     */
+    @Nullable
+    Message<byte[]> handle(@Nullable Message<byte[]> clientMessage, Throwable e);
+
+}

--- a/src/main/java/com/run_us/server/global/exception/SocketExceptionCustomHandler.java
+++ b/src/main/java/com/run_us/server/global/exception/SocketExceptionCustomHandler.java
@@ -7,7 +7,7 @@ public interface SocketExceptionCustomHandler {
     /**
      * 해당 핸들러가 처리할 수 있는 예외인지 반환
      * @param e : 확인할 예외
-     * @return 해당 ㅇ외 처리 가능여부
+     * @return 해당 예외 처리 가능여부
      */
     boolean canHandle(Throwable e);
 

--- a/src/main/java/com/run_us/server/global/exception/StompErrorHandler.java
+++ b/src/main/java/com/run_us/server/global/exception/StompErrorHandler.java
@@ -1,5 +1,6 @@
 package com.run_us.server.global.exception;
 
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.Message;
@@ -9,25 +10,23 @@ import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.web.socket.messaging.StompSubProtocolErrorHandler;
 
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 
 @Slf4j
 @Configuration
+@RequiredArgsConstructor
 public class StompErrorHandler extends StompSubProtocolErrorHandler {
+    private final List<SocketExceptionCustomHandler> handlers; // 추후 exception 별 별개의 처리가 필요할 경우 대비 - handler 따로따로 구현하면 됨
 
     @Override
     public Message<byte[]> handleClientMessageProcessingError(Message<byte[]> clientMessage, Throwable ex) {
 
         Throwable cause = ex.getCause();
-        if(cause instanceof BusinessException) {
-            return createErrorMessage((BusinessException) cause); // TODO : 여기서 대신 GlobalExceptionHandler 의 메서드를 호출해서 로직을 모아둘 수도 있음
+        for(SocketExceptionCustomHandler handler : handlers) {
+            if(handler.canHandle(cause)) {
+                return handler.handle(clientMessage, cause);
+            }
         }
-
         return super.handleClientMessageProcessingError(clientMessage, ex);
-    }
-
-    private Message<byte[]> createErrorMessage(BusinessException exception) {
-        StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.ERROR);
-        String errorMessage = exception.getLogMessage();
-        return MessageBuilder.createMessage(errorMessage.getBytes(StandardCharsets.UTF_8), accessor.getMessageHeaders());
     }
 }


### PR DESCRIPTION
### 연관된 이슈를 적어주세요 📌
x

### 작업한 내용을 설명해주세요 ✔️
- `GlobalSocketExceptionHandler` : 소켓 컨트롤러 단 에러 핸들러 구현
  - 여기서도 `sendToUser` 기능이 필요한데, 로직이 중복으로 여기저기 생기는 기분이라 특정유저에게 소켓응답해주는 부분을 모듈화하면 어떨까..? 생각해보고 있습니다. 
  전에 비슷한 경험으로 다른 프로젝트에서 소켓 응답 전송하는 부분들만 `~SocketResponser` 라는 이름의 클래스로 모아둔 적이 있어요. 꽤 괜찮았어서 `sendToUser` 메서드 빼놓는 것도 나쁘지 않을 것 같다는 생각이 들어요.
- `StompErrorHandler` : intercpetor 단에서 발생하는 에러 핸들링 후 연결 끊기지 않도록 변경
   - ERROR 프레임으로 응답되어 연결이 끊김 -> MESSAGE 로 응답되도록 변경
   - 에러가 잡혔을 때 어떤 에러인지 판단하는 부분만 기존 핸들러 `StompErrorHandler`에 남기고, 각 에러별 처리 로직을 담을 핸들러 클래스를 별도로 구현하여 분리
   - `SocketExceptionCustomHandler` : 처리 로직을 담는 핸들러들의 인터페이스
   - `SocketBusinessExceptionHandler` : 처리 로직을 담는 핸들러. `BusinessException` 만을 처리함
   지금 저희가 `BusinessException` 을 최상위 커스텀 예외로 사용하고 있어서 일단 그것만 구현했습니다.
   추후에 저희 커스텀 예외마다 다른 처리를 해줘야 하는 상황이 오면, 해당 핸들러는 제거하고 대신 이를 참고해 예외 별 처리 핸들러들을 만들어주면 됩니다.
  그냥 `StompErrorHandler` 에서 if 문 분기시킬까 하다가.. 나중에 지저분해질 거 같아서 분리해봤습니다
- 그리고 몇가지 상수값들 Const화 했어요
- `TestController` : 에러 발생시키는 요청 두개 만들었습니다. 테스트에 사용해주셔도 됩니다.

### 트러블 슈팅
x

### 리뷰어에게 하고 싶은 말을 적어주세요
에러 응답 실행 모습

- interceptor 단 에러
![interceptor 단 에러 응답](https://github.com/user-attachments/assets/6334b977-5465-4071-ab23-a2b0bc86cff5)

- controller 이후 단 에러
![controller 단 에러 응답](https://github.com/user-attachments/assets/c45e7c51-1fad-4696-80e6-f17942f28e69)

이렇게 오게 했습니다. body 를  json 으로 변경했어요
intercpetor 단 에러 응답 헤더가 비어보여서 뭐라도 넣을까하다가 딱히.. 필요성이 안느껴져서 일단 이렇게만 구현했습니다.

- sendToUser 모듈화는 어떻게 생각하시나요?

### 확인하기

- [ ] : 코드에 에러가 없는지 확인했나요?
- [ ] : PR에 설명을 기재했나요?
- [ ] : PR 태그를 붙였나요?
- [ ] : 불필요한 로그나 `System.out`을 제거했나요?