### PR TITLE
[Refactor/erd-sync] ERD에 맞게 타입 싱크

### DIFF
--- a/src/main/java/com/run_us/server/domains/running/controller/RunningController.java
+++ b/src/main/java/com/run_us/server/domains/running/controller/RunningController.java
@@ -1,9 +1,11 @@
 package com.run_us.server.domains.running.controller;
 
 import com.run_us.server.domains.running.controller.model.request.RunningCreateRequest;
+import com.run_us.server.domains.running.controller.model.response.RunningCreateResponse;
 import com.run_us.server.domains.running.service.RunningPreparationService;
 import com.run_us.server.domains.running.service.RunningResultService;
 import com.run_us.server.domains.running.service.model.JoinedParticipant;
+import com.run_us.server.domains.running.service.model.PersonalRecordQueryResult;
 import com.run_us.server.global.common.SuccessResponse;
 import com.run_us.server.global.exception.code.ExampleErrorCode;
 import java.util.List;
@@ -24,13 +26,13 @@ public class RunningController {
   private final RunningResultService runningResultService;
 
   @PostMapping
-  public SuccessResponse createRunning(@RequestBody RunningCreateRequest runningCreateDto) {
+  public SuccessResponse<RunningCreateResponse> createRunning(@RequestBody RunningCreateRequest runningCreateDto) {
     return SuccessResponse.of(ExampleErrorCode.SUCCESS,
         runningPreparationService.createRunning(runningCreateDto));
   }
 
   @GetMapping("/{runningId}/participants")
-  public SuccessResponse joinedParticipants(@PathVariable String runningId) {
+  public SuccessResponse<List<JoinedParticipant>> joinedParticipants(@PathVariable String runningId) {
     List<JoinedParticipant> joinedParticipants = runningPreparationService.getJoinedParticipants(
         runningId);
     return SuccessResponse.of(ExampleErrorCode.SUCCESS, joinedParticipants);
@@ -42,7 +44,7 @@ public class RunningController {
    * @param userId 사용자 고유번호
    * */
   @GetMapping("/{runningId}/records/{userId}")
-  public SuccessResponse getPersonalRecord(@PathVariable String runningId, @PathVariable String userId) {
+  public SuccessResponse<PersonalRecordQueryResult> getPersonalRecord(@PathVariable String runningId, @PathVariable String userId) {
     return SuccessResponse.of(ExampleErrorCode.SUCCESS,
         runningResultService.getPersonalRecord(runningId, userId));
   }

--- a/src/main/java/com/run_us/server/domains/running/domain/record/PersonalRecord.java
+++ b/src/main/java/com/run_us/server/domains/running/domain/record/PersonalRecord.java
@@ -1,15 +1,14 @@
 package com.run_us.server.domains.running.domain.record;
 
-import com.run_us.server.global.common.DateAudit;
+import com.run_us.server.global.common.CreationTimeAudit;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Lob;
 import jakarta.persistence.Table;
+import jakarta.persistence.AttributeOverride;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -19,21 +18,22 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class PersonalRecord extends DateAudit {
+@AttributeOverride(name = "createdAt", column = @Column(name = "uploaded_at"))
+public class PersonalRecord extends CreationTimeAudit {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  @Column(name = "personal_record_id")
-  private Long id;
+  @Column(name = "id", columnDefinition = "INT")
+  private Integer id;
 
-  @Column(name = "running_id", nullable = false)
-  private Long runningId;
+  @Column(name = "running_id", nullable = false, columnDefinition = "INT")
+  private Integer runningId;
 
-  @Column(name = "user_id", nullable = false)
-  private Long userId;
+  @Column(name = "user_id", nullable = false, columnDefinition = "INT")
+  private Integer userId;
 
   @Lob
-  @Column(name = "record_data", nullable = false)
+  @Column(name = "record_data", nullable = false, columnDefinition = "MEDIUMBLOB")
   private String recordData;
 
   @Column(name = "distance")
@@ -56,8 +56,8 @@ public class PersonalRecord extends DateAudit {
    */
   @Builder
   public PersonalRecord(
-      Long runningId,
-      Long userId,
+      Integer runningId,
+      Integer userId,
       String recordData,
       Integer runningDistanceInMeters,
       Integer runningDurationInMilliseconds,

--- a/src/main/java/com/run_us/server/domains/running/domain/record/RunningRecord.java
+++ b/src/main/java/com/run_us/server/domains/running/domain/record/RunningRecord.java
@@ -38,7 +38,7 @@ public class RunningRecord {
   private int finishCount;
 
   @Column(name = "total_distance", nullable = false)
-  private Integer totalDistance;
+  private Integer totalDistanceInMeter;
 
   /***
    * Constructor for RunningRecord
@@ -47,7 +47,7 @@ public class RunningRecord {
    * @param endTime 기록 종료 시간
    * @param participantCount 참가자 수
    * @param finishCount 완주자 수
-   * @param totalDistance 총 거리
+   * @param totalDistanceInMeter 총 거리
    */
   @Builder
   public RunningRecord(
@@ -56,9 +56,9 @@ public class RunningRecord {
       @NotNull ZonedDateTime endTime,
       int participantCount,
       int finishCount,
-      @NotNull Integer totalDistance) {
+      @NotNull Integer totalDistanceInMeter) {
     validateEndTime(startTime, endTime);
-    validateTotalDistance(totalDistance);
+    validateTotalDistance(totalDistanceInMeter);
     validateParticipantCount(participantCount);
     validateFinishCount(finishCount, participantCount);
     this.runningId = runningId;
@@ -66,7 +66,7 @@ public class RunningRecord {
     this.endTime = endTime;
     this.participantCount = participantCount;
     this.finishCount = finishCount;
-    this.totalDistance = totalDistance;
+    this.totalDistanceInMeter = totalDistanceInMeter;
   }
 
   private void validateFinishCount(int finishCount, int participantCount) {
@@ -90,8 +90,8 @@ public class RunningRecord {
     }
   }
 
-  private void validateTotalDistance(Integer totalDistance) {
-    if (totalDistance < 0) {
+  private void validateTotalDistance(Integer totalDistanceInMeter) {
+    if (totalDistanceInMeter < 0) {
       throw new IllegalArgumentException("총 거리는 0 이상이어야 합니다.");
     }
   }

--- a/src/main/java/com/run_us/server/domains/running/domain/record/RunningRecord.java
+++ b/src/main/java/com/run_us/server/domains/running/domain/record/RunningRecord.java
@@ -16,14 +16,14 @@ import lombok.NoArgsConstructor;
 @Table(name = "running_records")
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class RunningRecord extends DateAudit {
+public class RunningRecord {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  private Long id;
+  private Integer id;
 
   @Column(name = "running_id", nullable = false)
-  private Long runningId;
+  private Integer runningId;
 
   @Column(name = "start_time", nullable = false)
   private ZonedDateTime startTime;
@@ -38,7 +38,7 @@ public class RunningRecord extends DateAudit {
   private int finishCount;
 
   @Column(name = "total_distance", nullable = false)
-  private Double totalDistance;
+  private Integer totalDistance;
 
   /***
    * Constructor for RunningRecord
@@ -51,12 +51,12 @@ public class RunningRecord extends DateAudit {
    */
   @Builder
   public RunningRecord(
-      @NotNull Long runningId,
+      @NotNull Integer runningId,
       @NotNull ZonedDateTime startTime,
       @NotNull ZonedDateTime endTime,
       int participantCount,
       int finishCount,
-      @NotNull Double totalDistance) {
+      @NotNull Integer totalDistance) {
     validateEndTime(startTime, endTime);
     validateTotalDistance(totalDistance);
     validateParticipantCount(participantCount);
@@ -90,7 +90,7 @@ public class RunningRecord extends DateAudit {
     }
   }
 
-  private void validateTotalDistance(Double totalDistance) {
+  private void validateTotalDistance(Integer totalDistance) {
     if (totalDistance < 0) {
       throw new IllegalArgumentException("총 거리는 0 이상이어야 합니다.");
     }

--- a/src/main/java/com/run_us/server/domains/running/domain/running/Participants.java
+++ b/src/main/java/com/run_us/server/domains/running/domain/running/Participants.java
@@ -4,6 +4,7 @@ import jakarta.persistence.CollectionTable;
 import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Column;
 import java.io.Serializable;
 import java.util.HashSet;
 import java.util.List;
@@ -17,20 +18,21 @@ public class Participants implements Serializable {
 
   @ElementCollection
   @CollectionTable(
-      name = "participants",
+      name = "running_participants",
       joinColumns = @JoinColumn(name = "running_id")
   )
-  private Set<Long> participants = new HashSet<>();
+  @Column(name = "user_id")
+  private Set<Integer> participants = new HashSet<>();
 
-  public void add(Long participantId) {
+  public void add(Integer participantId) {
     this.participants.add(participantId);
   }
 
-  public void remove(Long participantId) {
+  public void remove(Integer participantId) {
     this.participants.remove(participantId);
   }
 
-  public boolean contains(Long participantId) {
+  public boolean contains(Integer participantId) {
     return this.participants.contains(participantId);
   }
 
@@ -38,7 +40,7 @@ public class Participants implements Serializable {
    * 참가자 목록을 반환합니다.
    * @return 참가자 목록
    */
-  public List<Long> getAllParticipantsId() {
+  public List<Integer> getAllParticipantsId() {
     return List.copyOf(participants);
   }
 }

--- a/src/main/java/com/run_us/server/domains/running/domain/running/Running.java
+++ b/src/main/java/com/run_us/server/domains/running/domain/running/Running.java
@@ -3,9 +3,11 @@ package com.run_us.server.domains.running.domain.running;
 import com.run_us.server.domains.running.domain.running.RunningConstraints.RunningConstraintsConverter;
 import com.run_us.server.domains.running.domain.running.RunningDescription.RunningDescriptionConverter;
 import com.run_us.server.domains.user.domain.User;
-import com.run_us.server.global.common.DateAudit;
+import com.run_us.server.global.common.CreationTimeAudit;
 import com.run_us.server.global.util.PassCodeGenerator;
 import io.hypersistence.tsid.TSID;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Embedded;
@@ -23,31 +25,29 @@ import org.locationtech.jts.geom.Point;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class Running extends DateAudit {
+@Table(name = "runnings")
+public class Running extends CreationTimeAudit {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  private Long id;
+  private Integer id;
 
-  @Column(name = "public_key", nullable = false)
+  @Column(name = "public_id", nullable = false, columnDefinition = "CHAR(13)")
   private String publicKey;
 
-  @Column(name = "passcode", nullable = false)
+  @Transient
   private String passcode;
 
   @Column(name = "start_location", nullable = false)
   private Point startLocation;
 
-  @Column(name = "running_constraints", nullable = false)
+  @Column(name = "constraints", nullable = false)
   @Convert(converter = RunningConstraintsConverter.class)
   private RunningConstraints constraints;
 
-  @Column(name = "running_annotation", nullable = false)
+  @Column(name = "annotation", nullable = false)
   @Convert(converter = RunningDescriptionConverter.class)
   private RunningDescription description;
-
-  @Column(name = "is_verified", nullable = false)
-  private boolean isVerified = false;
 
   @Embedded
   private Participants participants = new Participants();
@@ -73,12 +73,8 @@ public class Running extends DateAudit {
     this.participants.remove(user.getId());
   }
 
-  public List<Long> getAllParticipantsId() {
+  public List<Integer> getAllParticipantsId() {
     return this.participants.getAllParticipantsId();
-  }
-
-  public void verify() {
-    this.isVerified = true;
   }
 
   @Override

--- a/src/main/java/com/run_us/server/domains/running/repository/PersonalRecordRepository.java
+++ b/src/main/java/com/run_us/server/domains/running/repository/PersonalRecordRepository.java
@@ -17,7 +17,7 @@ public interface PersonalRecordRepository extends JpaRepository<PersonalRecord, 
             "p.createdAt) " +
             "FROM PersonalRecord p " +
             "WHERE p.userId = :userId AND p.runningId = :runningId")
-    Optional<PersonalRecordQueryResult> findByUserIdAndRunningId(Long userId, Long runningId);
+    Optional<PersonalRecordQueryResult> findByUserIdAndRunningId(Integer userId, Integer runningId);
 
     @Query("SELECT new com.run_us.server.domains.running.service.model.PersonalRecordQueryResult(" +
             "p.runningDistanceInMeters, " +
@@ -26,5 +26,5 @@ public interface PersonalRecordRepository extends JpaRepository<PersonalRecord, 
             "p.createdAt) " +
             "FROM PersonalRecord p " +
             "WHERE p.userId = :userId")
-    List<PersonalRecordQueryResult> findAllByUserId(Long userId);
+    List<PersonalRecordQueryResult> findAllByUserId(Integer userId);
 }

--- a/src/main/java/com/run_us/server/domains/running/service/RunningPreparationService.java
+++ b/src/main/java/com/run_us/server/domains/running/service/RunningPreparationService.java
@@ -48,7 +48,7 @@ public class RunningPreparationService {
   public List<JoinedParticipant> getJoinedParticipants(String runningId) {
     Running running = runningRepository.findByPublicKey(runningId)
         .orElseThrow(() -> RunningException.of(RunningErrorCode.RUNNING_NOT_FOUND));
-    List<Long> participantIds = running.getAllParticipantsId();
+    List<Integer> participantIds = running.getAllParticipantsId();
     return userRepository.findSimpleParticipantsByRunningId(participantIds);
   }
 

--- a/src/main/java/com/run_us/server/domains/running/service/RunningResultService.java
+++ b/src/main/java/com/run_us/server/domains/running/service/RunningResultService.java
@@ -66,7 +66,7 @@ public class RunningResultService {
      * @param userId 유저 고유번호
      * @return 개인 기록 리스트
      */
-    public List<PersonalRecordQueryResult> getAllPersonalRecords(Long userId) {
+    public List<PersonalRecordQueryResult> getAllPersonalRecords(Integer userId) {
       return personalRecordRepository.findAllByUserId(userId);
     }
 }

--- a/src/main/java/com/run_us/server/domains/running/service/model/RunningMapper.java
+++ b/src/main/java/com/run_us/server/domains/running/service/model/RunningMapper.java
@@ -28,8 +28,8 @@ public final class RunningMapper {
    * @param aggregateRunning 러닝결과 집계
    */
   public static PersonalRecord toPersonalRecord(
-          final Long userId,
-          final Long runningId,
+          final Integer userId,
+          final Integer runningId,
           final RunningAggregation aggregateRunning) {
     return PersonalRecord.builder()
         .runningId(runningId)

--- a/src/main/java/com/run_us/server/domains/user/controller/UserController.java
+++ b/src/main/java/com/run_us/server/domains/user/controller/UserController.java
@@ -1,6 +1,7 @@
 package com.run_us.server.domains.user.controller;
 
 import com.run_us.server.domains.user.controller.model.request.UserSignUpRequest;
+import com.run_us.server.domains.user.domain.Profile;
 import com.run_us.server.domains.user.domain.User;
 import com.run_us.server.domains.user.repository.UserRepository;
 import jakarta.transaction.Transactional;
@@ -20,10 +21,15 @@ public class UserController {
   @PostMapping("/auth/users")
   @Transactional
   public User createUser(@RequestBody UserSignUpRequest userSignUpRequest) {
+
+    Profile profile = Profile.builder()
+            .nickname(userSignUpRequest.getNickName())
+            .build();
+
     // create user
     User user = User.builder()
-        .nickname(userSignUpRequest.getNickName())
-        .build();
+            .profile(profile)
+            .build();
     return userRepository.save(user);
   }
 }

--- a/src/main/java/com/run_us/server/domains/user/domain/OAuthInfo.java
+++ b/src/main/java/com/run_us/server/domains/user/domain/OAuthInfo.java
@@ -1,6 +1,7 @@
 package com.run_us.server.domains.user.domain;
 
-import com.run_us.server.global.common.DateAudit;
+import com.run_us.server.global.common.CreationTimeAudit;
+import jakarta.persistence.Table;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -18,15 +19,17 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
+@Table(name = "oauth_accounts")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class OAuthInfo extends DateAudit {
+public class OAuthInfo extends CreationTimeAudit {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  private Long id;
+  @Column(columnDefinition = "INT")
+  private Integer id;
 
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "user_id", nullable = false)
+  @JoinColumn(name = "user_id", nullable = false, columnDefinition = "INT")
   private User user;
 
   @Enumerated(EnumType.STRING)

--- a/src/main/java/com/run_us/server/domains/user/domain/Penalty.java
+++ b/src/main/java/com/run_us/server/domains/user/domain/Penalty.java
@@ -28,7 +28,7 @@ public class Penalty {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  private Long id;
+  private Integer id;
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "user_id", nullable = false)
@@ -37,7 +37,7 @@ public class Penalty {
   @Column(name = "desc")
   private String description;
 
-  @Column(name = "penalty_type", nullable = false)
+  @Column(name = "type", nullable = false)
   private String penaltyType;
 
   @Column(name = "applied_at", nullable = false)

--- a/src/main/java/com/run_us/server/domains/user/domain/Profile.java
+++ b/src/main/java/com/run_us/server/domains/user/domain/Profile.java
@@ -58,9 +58,6 @@ public class Profile {
     @Column(name = "longest_time", nullable = false)
     private Integer longestTime = 0;
 
-    @Column(name = "updated_at", nullable = false)
-    private LocalDateTime updatedAt;
-
     @Builder
     public Profile(User user, String nickname, String imgUrl, LocalDate birthDate,
                    Gender gender, Integer pace) {

--- a/src/main/java/com/run_us/server/domains/user/domain/Profile.java
+++ b/src/main/java/com/run_us/server/domains/user/domain/Profile.java
@@ -26,9 +26,8 @@ public class Profile {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer id;
 
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
-    private User user;
+    @Column(name = "user_id")
+    private Integer userId;
 
     @Column(name = "nickname", nullable = false)
     private String nickname;
@@ -59,9 +58,9 @@ public class Profile {
     private Integer longestTime = 0;
 
     @Builder
-    public Profile(User user, String nickname, String imgUrl, LocalDate birthDate,
+    public Profile(Integer userId, String nickname, String imgUrl, LocalDate birthDate,
                    Gender gender, Integer pace) {
-        this.user = user;
+        this.userId = userId;
         this.nickname = nickname;
         this.imgUrl = imgUrl;
         this.birthDate = birthDate;

--- a/src/main/java/com/run_us/server/domains/user/domain/Profile.java
+++ b/src/main/java/com/run_us/server/domains/user/domain/Profile.java
@@ -1,0 +1,74 @@
+package com.run_us.server.domains.user.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import jakarta.persistence.Column;
+import jakarta.persistence.Id;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "profile")
+@Getter
+@NoArgsConstructor
+public class Profile {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "nickname", nullable = false)
+    private String nickname;
+
+    @Column(name = "img_url")
+    private String imgUrl;
+
+    @Column(name = "birth_date")
+    private LocalDate birthDate;
+
+    @Column(name = "gender")
+    @Enumerated(EnumType.STRING)
+    private Gender gender;
+
+    @Column(name = "pace")
+    private Integer pace;
+
+    @Column(name = "total_distance", nullable = false)
+    private Integer totalDistance = 0;
+
+    @Column(name = "total_time", nullable = false)
+    private Integer totalTime = 0;
+
+    @Column(name = "longest_distance", nullable = false)
+    private Integer longestDistance = 0;
+
+    @Column(name = "longest_time", nullable = false)
+    private Integer longestTime = 0;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @Builder
+    public Profile(User user, String nickname, String imgUrl, LocalDate birthDate,
+                   Gender gender, Integer pace) {
+        this.user = user;
+        this.nickname = nickname;
+        this.imgUrl = imgUrl;
+        this.birthDate = birthDate;
+        this.gender = gender;
+        this.pace = pace;
+    }
+}

--- a/src/main/java/com/run_us/server/domains/user/domain/User.java
+++ b/src/main/java/com/run_us/server/domains/user/domain/User.java
@@ -4,20 +4,18 @@ import com.run_us.server.global.common.DateAudit;
 import io.hypersistence.tsid.TSID;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
-import jakarta.validation.constraints.NotNull;
-import java.time.LocalDate;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.FetchType;
 import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
-import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.SQLRestriction;
 
 @Entity
@@ -30,25 +28,13 @@ public class User extends DateAudit{
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  @Column(name = "user_id")
-  private Long id;
+  private Integer id;
 
-  @Column(name = "public_id", nullable = false)
+  @Column(name = "public_id", nullable = false, columnDefinition = "CHAR(13)")
   private String publicId;
 
-  @Column(name = "nickname", nullable = false)
-  private String nickname;
-
-  @Column(name = "birth_date")
-  private LocalDate birthDate;
-
-  @Column(name = "gender")
-  @Enumerated(EnumType.STRING)
-  @ColumnDefault("'NONE'")
-  private Gender gender;
-
-  @Column(name = "img_url")
-  private String imgUrl;
+  @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+  private Profile profile;
 
   @Column(name = "deleted_at")
   private LocalDateTime deletedAt;
@@ -57,17 +43,11 @@ public class User extends DateAudit{
 
   /***
    * User 생성자
-   * @param nickname 사용자 닉네임, 중복가능, Not null
-   * @param birthDate 사용자 생년월일
-   * @param gender 사용자 성별, default NONE
-   * @param imgUrl 사용자 프로필 이미지 URL
+   * @param profile 프로필 정보
    */
   @Builder
-  public User(@NotNull String nickname, LocalDate birthDate, Gender gender, String imgUrl) {
-    this.nickname = nickname;
-    this.birthDate = birthDate;
-    this.gender = gender;
-    this.imgUrl = imgUrl;
+  private User(Profile profile) {
+    this.profile = profile;
   }
 
   @Override
@@ -79,12 +59,12 @@ public class User extends DateAudit{
   // 비즈니스 로직 메소드
 
   /**
-   * change profile image url method
+   * change profile method
    *
-   * @param newImgUrl 변경할 이미지 URL
+   * @param profile 변경할 프로필 정보
    * */
-  public void changeProfileImgUrl(@NotNull String newImgUrl) {
-    this.imgUrl = newImgUrl;
+  public void setProfile(Profile profile) {
+    this.profile = profile;
   }
 
   /***

--- a/src/main/java/com/run_us/server/domains/user/domain/User.java
+++ b/src/main/java/com/run_us/server/domains/user/domain/User.java
@@ -9,6 +9,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.persistence.OneToOne;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.FetchType;
 import java.time.LocalDateTime;
@@ -33,7 +34,8 @@ public class User extends DateAudit{
   @Column(name = "public_id", nullable = false, columnDefinition = "CHAR(13)")
   private String publicId;
 
-  @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+  @OneToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+  @JoinColumn(name = "id", referencedColumnName = "user_id")
   private Profile profile;
 
   @Column(name = "deleted_at")

--- a/src/main/java/com/run_us/server/domains/user/repository/PenaltyRepository.java
+++ b/src/main/java/com/run_us/server/domains/user/repository/PenaltyRepository.java
@@ -10,5 +10,5 @@ import org.springframework.stereotype.Repository;
 public interface PenaltyRepository extends JpaRepository<Penalty, Long> {
 
   @Query("SELECT p FROM Penalty p WHERE p.user.id = :userId")
-  List<Penalty> findByUserId(Long userId);
+  List<Penalty> findByUserId(Integer userId);
 }

--- a/src/main/java/com/run_us/server/domains/user/repository/UserRepository.java
+++ b/src/main/java/com/run_us/server/domains/user/repository/UserRepository.java
@@ -20,7 +20,6 @@ public interface UserRepository extends JpaRepository<User, Long>{
 
   @Query("SELECT new com.run_us.server.domains.running.service.model.JoinedParticipant(p.nickname, p.imgUrl)"
           + " FROM Profile p"
-          + " WHERE p.userId IN :participantIds"
-          + " AND p.userId IN (SELECT u.id FROM User u WHERE u.deletedAt IS NULL)")
+          + " WHERE p.userId IN :participantIds")
   List<JoinedParticipant> findSimpleParticipantsByRunningId(List<Integer> participantIds);
 }

--- a/src/main/java/com/run_us/server/domains/user/repository/UserRepository.java
+++ b/src/main/java/com/run_us/server/domains/user/repository/UserRepository.java
@@ -12,16 +12,15 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface UserRepository extends JpaRepository<User, Long>{
 
-  @Query("SELECT p FROM Profile p JOIN FETCH p.user u WHERE p.nickname = :nickname AND u.deletedAt IS NULL")
-  Optional<Profile> findByNickname(String nickname);
+  @Query("SELECT u FROM User u JOIN u.profile p WHERE p.nickname = :nickname AND u.deletedAt IS NULL")
+  Optional<User> findByNickname(String nickname);
 
   @Query("SELECT u FROM User u WHERE u.publicId = :publicId AND u.deletedAt IS NULL")
   Optional<User> findByPublicId(String publicId);
 
   @Query("SELECT new com.run_us.server.domains.running.service.model.JoinedParticipant(p.nickname, p.imgUrl)"
-          + " FROM User u"
-          + " JOIN u.profile p"
-          + " WHERE u.id IN :participantIds"
-          + " AND u.deletedAt IS NULL")
+          + " FROM Profile p"
+          + " WHERE p.userId IN :participantIds"
+          + " AND p.userId IN (SELECT u.id FROM User u WHERE u.deletedAt IS NULL)")
   List<JoinedParticipant> findSimpleParticipantsByRunningId(List<Integer> participantIds);
 }

--- a/src/main/java/com/run_us/server/domains/user/repository/UserRepository.java
+++ b/src/main/java/com/run_us/server/domains/user/repository/UserRepository.java
@@ -1,6 +1,7 @@
 package com.run_us.server.domains.user.repository;
 
 import com.run_us.server.domains.running.service.model.JoinedParticipant;
+import com.run_us.server.domains.user.domain.Profile;
 import com.run_us.server.domains.user.domain.User;
 import java.util.List;
 import java.util.Optional;
@@ -11,12 +12,16 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface UserRepository extends JpaRepository<User, Long>{
 
-  Optional<User> findByNickname(String nickname);
+  @Query("SELECT p FROM Profile p JOIN FETCH p.user u WHERE p.nickname = :nickname AND u.deletedAt IS NULL")
+  Optional<Profile> findByNickname(String nickname);
 
   @Query("SELECT u FROM User u WHERE u.publicId = :publicId AND u.deletedAt IS NULL")
   Optional<User> findByPublicId(String publicId);
 
-  @Query("SELECT new com.run_us.server.domains.running.service.model.JoinedParticipant(u.nickname, u.imgUrl)"
-      + " FROM User u WHERE u.id IN :participantIds")
-  List<JoinedParticipant> findSimpleParticipantsByRunningId(List<Long> participantIds);
+  @Query("SELECT new com.run_us.server.domains.running.service.model.JoinedParticipant(p.nickname, p.imgUrl)"
+          + " FROM User u"
+          + " JOIN u.profile p"
+          + " WHERE u.id IN :participantIds"
+          + " AND u.deletedAt IS NULL")
+  List<JoinedParticipant> findSimpleParticipantsByRunningId(List<Integer> participantIds);
 }

--- a/src/main/java/com/run_us/server/domains/user/service/UserAuthService.java
+++ b/src/main/java/com/run_us/server/domains/user/service/UserAuthService.java
@@ -2,6 +2,7 @@ package com.run_us.server.domains.user.service;
 
 import com.run_us.server.domains.user.controller.model.request.UserSignUpRequest;
 import com.run_us.server.domains.user.domain.User;
+import com.run_us.server.domains.user.domain.Profile;
 import com.run_us.server.domains.user.domain.OAuthInfo;
 import com.run_us.server.domains.user.domain.TokenPair;
 import com.run_us.server.domains.user.domain.AuthResult;
@@ -53,8 +54,12 @@ public class UserAuthService {
     }
 
     private User createAndSaveUser(UserSignUpRequest userSignUpRequest) {
-        User user = User.builder()
+        Profile profile = Profile.builder()
                 .nickname(userSignUpRequest.getNickName())
+                .build();
+
+        User user = User.builder()
+                .profile(profile)
                 .build();
         return userRepository.save(user);
     }

--- a/src/main/java/com/run_us/server/global/common/CreationTimeAudit.java
+++ b/src/main/java/com/run_us/server/global/common/CreationTimeAudit.java
@@ -1,0 +1,22 @@
+package com.run_us.server.global.common;
+
+import static com.run_us.server.global.common.GlobalConst.TIME_ZONE_ID;
+
+import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.PrePersist;
+import java.io.Serializable;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import lombok.Getter;
+
+@MappedSuperclass
+@Getter
+public abstract class CreationTimeAudit implements Serializable {
+
+    protected ZonedDateTime createdAt;
+
+    @PrePersist
+    protected void prePersist() {
+        this.createdAt = ZonedDateTime.now(ZoneId.of(TIME_ZONE_ID));
+    }
+}

--- a/src/main/java/com/run_us/server/global/common/DateAudit.java
+++ b/src/main/java/com/run_us/server/global/common/DateAudit.java
@@ -3,24 +3,20 @@ package com.run_us.server.global.common;
 import static com.run_us.server.global.common.GlobalConst.TIME_ZONE_ID;
 
 import jakarta.persistence.MappedSuperclass;
-import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreUpdate;
-import java.io.Serializable;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import lombok.Getter;
 
 @MappedSuperclass
 @Getter
-public abstract class DateAudit implements Serializable {
-
-  protected ZonedDateTime createdAt;
+public abstract class DateAudit extends CreationTimeAudit {
 
   protected ZonedDateTime updatedAt;
 
-  @PrePersist
+  @Override
   protected void prePersist() {
-    this.createdAt = ZonedDateTime.now(ZoneId.of(TIME_ZONE_ID));
+    super.prePersist();
     this.updatedAt = ZonedDateTime.now(ZoneId.of(TIME_ZONE_ID));
   }
 

--- a/src/main/java/com/run_us/server/global/common/SuccessResponse.java
+++ b/src/main/java/com/run_us/server/global/common/SuccessResponse.java
@@ -4,20 +4,20 @@ import com.run_us.server.global.exception.code.CustomResponseCode;
 import lombok.Getter;
 
 @Getter
-public class SuccessResponse extends Response {
+public class SuccessResponse<T> extends Response {
 
-  private final Object payload;
+  private final T payload;
 
-  private SuccessResponse(final CustomResponseCode code, final Object payload) {
+  private SuccessResponse(final CustomResponseCode code, final T payload) {
     super(true, code);
     this.payload = payload;
   }
 
-  public static SuccessResponse messageOnly(final CustomResponseCode code) {
-    return new SuccessResponse(code, null);
+  public static SuccessResponse<Void> messageOnly(final CustomResponseCode code) {
+    return new SuccessResponse<>(code, null);
   }
 
-  public static SuccessResponse of(final CustomResponseCode code, final Object payload) {
-    return new SuccessResponse(code, payload);
+  public static <T> SuccessResponse<T> of(final CustomResponseCode code, final T payload) {
+    return new SuccessResponse<>(code, payload);
   }
 }

--- a/src/test/java/com/run_us/server/domains/running/PersonalRecordFixtures.java
+++ b/src/test/java/com/run_us/server/domains/running/PersonalRecordFixtures.java
@@ -4,7 +4,7 @@ import com.run_us.server.domains.running.domain.record.PersonalRecord;
 
 public final class PersonalRecordFixtures {
 
-    public static PersonalRecord getPersonalRecordWithUserIdAndRunningId(Long userId, Long runningId) {
+    public static PersonalRecord getPersonalRecordWithUserIdAndRunningId(Integer userId, Integer runningId) {
         return PersonalRecord.builder()
             .runningId(userId)
             .userId(runningId)

--- a/src/test/java/com/run_us/server/domains/running/RunningControllerTest.java
+++ b/src/test/java/com/run_us/server/domains/running/RunningControllerTest.java
@@ -22,6 +22,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @SpringBootTest
 @Import(TestRedisConfiguration.class)
@@ -41,9 +42,6 @@ class RunningControllerTest {
   @Autowired
     private PersonalRecordRepository personalRecordRepository;
 
-  @Autowired
-  private UserFixtures userFixtures;
-
   @Nested
   @DisplayName("fetchRunningParticipants 메소드는")
   class Describe_fetchRunningParticipants {
@@ -53,8 +51,14 @@ class RunningControllerTest {
     @BeforeEach
     void setUp() {
       // save users
-      User u1 = userFixtures.getDefaultUserWithNickname("us1");
-      User u2 = userFixtures.getDefaultUserWithNickname("us2");
+      User u1 = UserFixtures.getDefaultUserWithNickname("us1");
+      ReflectionTestUtils.setField(u1, "id", 100);
+      ReflectionTestUtils.setField(u1.getProfile(), "userId", 100);
+
+      User u2 = UserFixtures.getDefaultUserWithNickname("us2");
+      ReflectionTestUtils.setField(u2, "id", 200);
+      ReflectionTestUtils.setField(u2.getProfile(), "userId", 200);
+
       userRepository.saveAndFlush(u1);
       userRepository.saveAndFlush(u2);
 
@@ -86,8 +90,11 @@ class RunningControllerTest {
         @BeforeEach
         void setUp() {
           // save users
-          u1 = userFixtures.getDefaultUserWithNickname("us1");
+          u1 = UserFixtures.getDefaultUserWithNickname("us1");
+          ReflectionTestUtils.setField(u1, "id", 11);
+          ReflectionTestUtils.setField(u1.getProfile(), "userId", 11);
           userRepository.saveAndFlush(u1);
+          u1 = userRepository.findByNickname("us1").get();
           // create running
           r1 = RunningFixtures.getDefaultRunningWithParticipants(List.of(u1));
           runningRepository.saveAndFlush(r1);

--- a/src/test/java/com/run_us/server/domains/running/RunningControllerTest.java
+++ b/src/test/java/com/run_us/server/domains/running/RunningControllerTest.java
@@ -100,7 +100,7 @@ class RunningControllerTest {
           String runningId = r1.getPublicKey();
           String userId = u1.getPublicId();
           // when
-          SuccessResponse successResponse = runningController.getPersonalRecord(runningId, userId);
+          SuccessResponse<PersonalRecordQueryResult> successResponse = runningController.getPersonalRecord(runningId, userId);
           PersonalRecordQueryResult personalRecord = (PersonalRecordQueryResult) successResponse.getPayload();
           //then
           Assertions.assertNotNull(successResponse.getPayload());

--- a/src/test/java/com/run_us/server/domains/running/RunningControllerTest.java
+++ b/src/test/java/com/run_us/server/domains/running/RunningControllerTest.java
@@ -41,6 +41,9 @@ class RunningControllerTest {
   @Autowired
     private PersonalRecordRepository personalRecordRepository;
 
+  @Autowired
+  private UserFixtures userFixtures;
+
   @Nested
   @DisplayName("fetchRunningParticipants 메소드는")
   class Describe_fetchRunningParticipants {
@@ -50,8 +53,8 @@ class RunningControllerTest {
     @BeforeEach
     void setUp() {
       // save users
-      User u1 = UserFixtures.getDefaultUserWithNickname("us1");
-      User u2 = UserFixtures.getDefaultUserWithNickname("us2");
+      User u1 = userFixtures.getDefaultUserWithNickname("us1");
+      User u2 = userFixtures.getDefaultUserWithNickname("us2");
       userRepository.saveAndFlush(u1);
       userRepository.saveAndFlush(u2);
 
@@ -66,8 +69,8 @@ class RunningControllerTest {
       // given
       String runningId = r1.getPublicKey();
       // when
-      SuccessResponse successResponse = runningController.joinedParticipants(runningId);
-      List<JoinedParticipant> joinedParticipants = (List<JoinedParticipant>) successResponse.getPayload();
+      SuccessResponse<List<JoinedParticipant>> successResponse = runningController.joinedParticipants(runningId);
+      List<JoinedParticipant> joinedParticipants = successResponse.getPayload();
       //then
       Assertions.assertEquals(2, joinedParticipants.size());
     }
@@ -83,7 +86,7 @@ class RunningControllerTest {
         @BeforeEach
         void setUp() {
           // save users
-          u1 = UserFixtures.getDefaultUserWithNickname("us1");
+          u1 = userFixtures.getDefaultUserWithNickname("us1");
           userRepository.saveAndFlush(u1);
           // create running
           r1 = RunningFixtures.getDefaultRunningWithParticipants(List.of(u1));

--- a/src/test/java/com/run_us/server/domains/running/RunningTest.java
+++ b/src/test/java/com/run_us/server/domains/running/RunningTest.java
@@ -12,17 +12,10 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Point;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.util.ReflectionTestUtils;
 
-@SpringBootTest
 @DisplayName("Running 클래스의")
 class RunningTest {
-
-  @Autowired
-  private UserFixtures userFixtures;
-
   @Nested
   @DisplayName("생성자는")
   class Describe_constructor {
@@ -50,7 +43,7 @@ class RunningTest {
     @Nested
     @DisplayName("유저를 입력으로 받았을 때")
     class Context_with_valid_arguments {
-      User participant = userFixtures.getDefaultUser();
+      User participant = UserFixtures.getDefaultUser();
 
       @Test
       @DisplayName("참가자목록에 유저 ID를 추가한다")
@@ -70,7 +63,7 @@ class RunningTest {
     @Nested
     @DisplayName("유저를 입력으로 받았을때")
     class Context_with_participant {
-      User participant = userFixtures.getDefaultUser();
+      User participant = UserFixtures.getDefaultUser();
       @Test
       @DisplayName("유저가 있는지 확인하고 유저가 있다면 true를 반환한다")
       void it_checks_participant_exists() {
@@ -96,7 +89,7 @@ class RunningTest {
     @Nested
     @DisplayName("유저를 입력으로 받았을때")
     class Context_with_participant {
-      User participant = userFixtures.getDefaultUser();
+      User participant = UserFixtures.getDefaultUser();
       @Test
       @DisplayName("참가자목록에서 해당 유저 ID를 제거한다")
       void it_removes_a_participant() {
@@ -116,8 +109,8 @@ class RunningTest {
     @Nested
     @DisplayName("참가자가 있는 경우")
     class Context_with_participants {
-      User participant1 = userFixtures.getDefaultUser();
-      User participant2 = userFixtures.getDefaultUserWithNickname("participant2");
+      User participant1 = UserFixtures.getDefaultUser();
+      User participant2 = UserFixtures.getDefaultUserWithNickname("participant2");
 
       @Test
       @DisplayName("참가자 목록을 반환한다")

--- a/src/test/java/com/run_us/server/domains/running/RunningTest.java
+++ b/src/test/java/com/run_us/server/domains/running/RunningTest.java
@@ -48,7 +48,7 @@ class RunningTest {
       @Test
       @DisplayName("참가자목록에 유저 ID를 추가한다")
       void it_adds_a_participant() {
-        ReflectionTestUtils.setField(participant, "id", 1L);
+        ReflectionTestUtils.setField(participant, "id", 1);
         running.addParticipant(participant);
         assertTrue(running.hasParticipant(participant));
       }
@@ -67,7 +67,7 @@ class RunningTest {
       @Test
       @DisplayName("유저가 있는지 확인하고 유저가 있다면 true를 반환한다")
       void it_checks_participant_exists() {
-        ReflectionTestUtils.setField(participant, "id", 1L);
+        ReflectionTestUtils.setField(participant, "id", 1);
         running.addParticipant(participant);
         assertTrue(running.hasParticipant(participant));
       }
@@ -75,7 +75,7 @@ class RunningTest {
       @Test
       @DisplayName("유저가 있는지 확인하고 유저가 없다면 false를 반환한다")
       void it_checks_participant_non_exists() {
-        ReflectionTestUtils.setField(participant, "id", 2L);
+        ReflectionTestUtils.setField(participant, "id", 2);
         assertFalse(running.hasParticipant(participant));
       }
     }
@@ -93,7 +93,7 @@ class RunningTest {
       @Test
       @DisplayName("참가자목록에서 해당 유저 ID를 제거한다")
       void it_removes_a_participant() {
-        ReflectionTestUtils.setField(participant, "id", 1L);
+        ReflectionTestUtils.setField(participant, "id", 1);
         running.addParticipant(participant);
         running.removeParticipant(participant);
         assertFalse(running.hasParticipant(participant));
@@ -115,8 +115,8 @@ class RunningTest {
       @Test
       @DisplayName("참가자 목록을 반환한다")
       void it_returns_participants() {
-        ReflectionTestUtils.setField(participant1, "id", 1L);
-        ReflectionTestUtils.setField(participant2, "id", 2L);
+        ReflectionTestUtils.setField(participant1, "id", 1);
+        ReflectionTestUtils.setField(participant2, "id", 2);
         running.addParticipant(participant1);
         running.addParticipant(participant2);
         assertEquals(2, running.getAllParticipantsId().size());

--- a/src/test/java/com/run_us/server/domains/running/RunningTest.java
+++ b/src/test/java/com/run_us/server/domains/running/RunningTest.java
@@ -12,10 +12,17 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Point;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.util.ReflectionTestUtils;
 
+@SpringBootTest
 @DisplayName("Running 클래스의")
 class RunningTest {
+
+  @Autowired
+  private UserFixtures userFixtures;
+
   @Nested
   @DisplayName("생성자는")
   class Describe_constructor {
@@ -43,7 +50,7 @@ class RunningTest {
     @Nested
     @DisplayName("유저를 입력으로 받았을 때")
     class Context_with_valid_arguments {
-      User participant = UserFixtures.getDefaultUser();
+      User participant = userFixtures.getDefaultUser();
 
       @Test
       @DisplayName("참가자목록에 유저 ID를 추가한다")
@@ -63,7 +70,7 @@ class RunningTest {
     @Nested
     @DisplayName("유저를 입력으로 받았을때")
     class Context_with_participant {
-      User participant = UserFixtures.getDefaultUser();
+      User participant = userFixtures.getDefaultUser();
       @Test
       @DisplayName("유저가 있는지 확인하고 유저가 있다면 true를 반환한다")
       void it_checks_participant_exists() {
@@ -89,7 +96,7 @@ class RunningTest {
     @Nested
     @DisplayName("유저를 입력으로 받았을때")
     class Context_with_participant {
-      User participant = UserFixtures.getDefaultUser();
+      User participant = userFixtures.getDefaultUser();
       @Test
       @DisplayName("참가자목록에서 해당 유저 ID를 제거한다")
       void it_removes_a_participant() {
@@ -109,8 +116,8 @@ class RunningTest {
     @Nested
     @DisplayName("참가자가 있는 경우")
     class Context_with_participants {
-      User participant1 = UserFixtures.getDefaultUser();
-      User participant2 = UserFixtures.getDefaultUserWithNickname("participant2");
+      User participant1 = userFixtures.getDefaultUser();
+      User participant2 = userFixtures.getDefaultUserWithNickname("participant2");
 
       @Test
       @DisplayName("참가자 목록을 반환한다")

--- a/src/test/java/com/run_us/server/domains/user/domain/PenaltyRepositoryTest.java
+++ b/src/test/java/com/run_us/server/domains/user/domain/PenaltyRepositoryTest.java
@@ -38,11 +38,11 @@ class PenaltyRepositoryTest {
         .expiresAt(ZonedDateTime.of(LocalDateTime.now(), ZoneId.of(TIME_ZONE_ID)))
         .build();
     //when
-    User savedUser = userRepository.findByNickname("NICKNAME").get();
-    penalty.applyPenaltyToUser(savedUser);
+    Profile savedUser = userRepository.findByNickname("NICKNAME").get();
+    penalty.applyPenaltyToUser(savedUser.getUser());
     penaltyRepository.save(penalty);
 
-    List<Penalty> createdPenalty = penaltyRepository.findByUserId(savedUser.getId());
+    List<Penalty> createdPenalty = penaltyRepository.findByUserId(savedUser.getUser().getId());
 
     //then
     assertFalse(createdPenalty.isEmpty());

--- a/src/test/java/com/run_us/server/domains/user/domain/PenaltyRepositoryTest.java
+++ b/src/test/java/com/run_us/server/domains/user/domain/PenaltyRepositoryTest.java
@@ -13,9 +13,11 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.transaction.annotation.Transactional;
 
 @DataJpaTest
+@Import(UserFixtures.class)
 class PenaltyRepositoryTest {
 
   @Autowired
@@ -24,11 +26,14 @@ class PenaltyRepositoryTest {
   @Autowired
   private UserRepository userRepository;
 
+  @Autowired
+  private UserFixtures userFixtures;
+
   @Transactional
   @Test
   void create_penalty() {
     //given
-    User user = UserFixtures.getDefaultUser();
+    User user = userFixtures.getDefaultUser();
     userRepository.saveAndFlush(user);
 
 
@@ -38,11 +43,11 @@ class PenaltyRepositoryTest {
         .expiresAt(ZonedDateTime.of(LocalDateTime.now(), ZoneId.of(TIME_ZONE_ID)))
         .build();
     //when
-    Profile savedUser = userRepository.findByNickname("NICKNAME").get();
-    penalty.applyPenaltyToUser(savedUser.getUser());
+    User savedUser = userRepository.findByNickname("NICKNAME").get();
+    penalty.applyPenaltyToUser(savedUser);
     penaltyRepository.save(penalty);
 
-    List<Penalty> createdPenalty = penaltyRepository.findByUserId(savedUser.getUser().getId());
+    List<Penalty> createdPenalty = penaltyRepository.findByUserId(savedUser.getId());
 
     //then
     assertFalse(createdPenalty.isEmpty());

--- a/src/test/java/com/run_us/server/domains/user/domain/PenaltyRepositoryTest.java
+++ b/src/test/java/com/run_us/server/domains/user/domain/PenaltyRepositoryTest.java
@@ -13,11 +13,10 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.context.annotation.Import;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.transaction.annotation.Transactional;
 
 @DataJpaTest
-@Import(UserFixtures.class)
 class PenaltyRepositoryTest {
 
   @Autowired
@@ -26,14 +25,13 @@ class PenaltyRepositoryTest {
   @Autowired
   private UserRepository userRepository;
 
-  @Autowired
-  private UserFixtures userFixtures;
-
   @Transactional
   @Test
   void create_penalty() {
     //given
-    User user = userFixtures.getDefaultUser();
+    User user = UserFixtures.getDefaultUser();
+    ReflectionTestUtils.setField(user, "id", 1);
+    ReflectionTestUtils.setField(user.getProfile(), "userId", 1);
     userRepository.saveAndFlush(user);
 
 

--- a/src/test/java/com/run_us/server/domains/user/domain/UserFixtures.java
+++ b/src/test/java/com/run_us/server/domains/user/domain/UserFixtures.java
@@ -1,29 +1,47 @@
 package com.run_us.server.domains.user.domain;
 
+import com.run_us.server.domains.user.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
 import java.time.LocalDate;
 
+@Component
 public final class UserFixtures {
+
+  private final UserRepository userRepository;
+
+  @Autowired
+  public UserFixtures(UserRepository userRepository) {
+    this.userRepository = userRepository;
+  }
 
   public static final LocalDate DEFAULT_BIRTH_DATE = LocalDate.of(1999, 1, 1);
 
-  public static User getDefaultUser() {
+  public User getDefaultUser() {
     User user = User.builder().build();
+    userRepository.save(user);
+
     Profile profile = Profile.builder()
-            .user(user)
+            .userId(user.getId())
             .nickname("NICKNAME")
             .build();
+
     user.setProfile(profile);
     return user;
   }
 
-  public static User getDefaultUserWithNickname(String nickname) {
+  public User getDefaultUserWithNickname(String nickname) {
     User user = User.builder().build();
+    userRepository.save(user);
+
     Profile profile = Profile.builder()
-            .user(user)
+            .userId(user.getId())
             .nickname(nickname)
             .birthDate(DEFAULT_BIRTH_DATE)
             .gender(Gender.NONE)
             .build();
+
     user.setProfile(profile);
     return user;
   }

--- a/src/test/java/com/run_us/server/domains/user/domain/UserFixtures.java
+++ b/src/test/java/com/run_us/server/domains/user/domain/UserFixtures.java
@@ -1,47 +1,29 @@
 package com.run_us.server.domains.user.domain;
 
-import com.run_us.server.domains.user.repository.UserRepository;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
-
 import java.time.LocalDate;
 
-@Component
 public final class UserFixtures {
-
-  private final UserRepository userRepository;
-
-  @Autowired
-  public UserFixtures(UserRepository userRepository) {
-    this.userRepository = userRepository;
-  }
 
   public static final LocalDate DEFAULT_BIRTH_DATE = LocalDate.of(1999, 1, 1);
 
-  public User getDefaultUser() {
+  public static User getDefaultUser() {
     User user = User.builder().build();
-    userRepository.save(user);
-
     Profile profile = Profile.builder()
             .userId(user.getId())
             .nickname("NICKNAME")
             .build();
-
     user.setProfile(profile);
     return user;
   }
 
-  public User getDefaultUserWithNickname(String nickname) {
+  public static User getDefaultUserWithNickname(String nickname) {
     User user = User.builder().build();
-    userRepository.save(user);
-
     Profile profile = Profile.builder()
             .userId(user.getId())
             .nickname(nickname)
             .birthDate(DEFAULT_BIRTH_DATE)
             .gender(Gender.NONE)
             .build();
-
     user.setProfile(profile);
     return user;
   }

--- a/src/test/java/com/run_us/server/domains/user/domain/UserFixtures.java
+++ b/src/test/java/com/run_us/server/domains/user/domain/UserFixtures.java
@@ -7,18 +7,24 @@ public final class UserFixtures {
   public static final LocalDate DEFAULT_BIRTH_DATE = LocalDate.of(1999, 1, 1);
 
   public static User getDefaultUser() {
-    return User.builder()
-        .nickname("NICKNAME")
-        .birthDate(DEFAULT_BIRTH_DATE)
-        .gender(Gender.NONE)
-        .build();
+    User user = User.builder().build();
+    Profile profile = Profile.builder()
+            .user(user)
+            .nickname("NICKNAME")
+            .build();
+    user.setProfile(profile);
+    return user;
   }
 
   public static User getDefaultUserWithNickname(String nickname) {
-    return User.builder()
-        .nickname(nickname)
-        .birthDate(DEFAULT_BIRTH_DATE)
-        .gender(Gender.NONE)
-        .build();
+    User user = User.builder().build();
+    Profile profile = Profile.builder()
+            .user(user)
+            .nickname(nickname)
+            .birthDate(DEFAULT_BIRTH_DATE)
+            .gender(Gender.NONE)
+            .build();
+    user.setProfile(profile);
+    return user;
   }
 }

--- a/src/test/java/com/run_us/server/domains/user/domain/UserRepositoryTest.java
+++ b/src/test/java/com/run_us/server/domains/user/domain/UserRepositoryTest.java
@@ -9,46 +9,45 @@ import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.context.annotation.Import;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.transaction.annotation.Transactional;
 
 @DataJpaTest
-@Import(UserFixtures.class)
 class UserRepositoryTest {
 
   @Autowired
   private UserRepository userRepository;
 
-  @Autowired
-  private UserFixtures userFixtures;
-
   @Transactional
   @Test
   void create_user() {
     //given
-    User user = userFixtures.getDefaultUser();
+    User user = UserFixtures.getDefaultUserWithNickname("CREATED_USER");
+    ReflectionTestUtils.setField(user, "id", 500);
+    ReflectionTestUtils.setField(user.getProfile(), "userId", 500);
 
     //when
     userRepository.save(user);
-    Optional<User> createdUser = userRepository.findByNickname("NICKNAME");
+    Optional<User> createdUser = userRepository.findByNickname("CREATED_USER");
 
     //then
     assertTrue(createdUser.isPresent());
-    assertEquals("NICKNAME", createdUser.get().getProfile().getNickname());
+    assertEquals("CREATED_USER", createdUser.get().getProfile().getNickname());
     assertNotNull(createdUser.get().getPublicId());
-    assertEquals(user.getId(), createdUser.get().getId());
   }
 
   @Transactional
   @Test
   void remove_user() {
     //given
-    User user = userFixtures.getDefaultUser();
+    User user = UserFixtures.getDefaultUserWithNickname("REMOVED_USER");
+    ReflectionTestUtils.setField(user, "id", 1);
+    ReflectionTestUtils.setField(user.getProfile(), "userId", 1);
+    user.remove();
     userRepository.save(user);
 
     //when
-    user.remove();
-    Optional<User> removedUser = userRepository.findByNickname("NICKNAME");
+    Optional<User> removedUser = userRepository.findByNickname("REMOVED_USER");
 
     //then
     assertNotNull(user.getDeletedAt());

--- a/src/test/java/com/run_us/server/domains/user/domain/UserRepositoryTest.java
+++ b/src/test/java/com/run_us/server/domains/user/domain/UserRepositoryTest.java
@@ -9,28 +9,33 @@ import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.transaction.annotation.Transactional;
 
 @DataJpaTest
+@Import(UserFixtures.class)
 class UserRepositoryTest {
 
   @Autowired
   private UserRepository userRepository;
 
+  @Autowired
+  private UserFixtures userFixtures;
+
   @Transactional
   @Test
   void create_user() {
     //given
-    User user = UserFixtures.getDefaultUser();
+    User user = userFixtures.getDefaultUser();
 
     //when
     userRepository.save(user);
-    Optional<Profile> createdUser = userRepository.findByNickname("NICKNAME");
+    Optional<User> createdUser = userRepository.findByNickname("NICKNAME");
 
     //then
     assertTrue(createdUser.isPresent());
-    assertEquals("NICKNAME", createdUser.get().getNickname());
-    assertNotNull(createdUser.get().getUser().getPublicId());
+    assertEquals("NICKNAME", createdUser.get().getProfile().getNickname());
+    assertNotNull(createdUser.get().getPublicId());
     assertEquals(user.getId(), createdUser.get().getId());
   }
 
@@ -38,12 +43,12 @@ class UserRepositoryTest {
   @Test
   void remove_user() {
     //given
-    User user = UserFixtures.getDefaultUser();
+    User user = userFixtures.getDefaultUser();
     userRepository.save(user);
 
     //when
     user.remove();
-    Optional<Profile> removedUser = userRepository.findByNickname("NICKNAME");
+    Optional<User> removedUser = userRepository.findByNickname("NICKNAME");
 
     //then
     assertNotNull(user.getDeletedAt());

--- a/src/test/java/com/run_us/server/domains/user/domain/UserRepositoryTest.java
+++ b/src/test/java/com/run_us/server/domains/user/domain/UserRepositoryTest.java
@@ -25,11 +25,13 @@ class UserRepositoryTest {
 
     //when
     userRepository.save(user);
-    Optional<User> createdUser = userRepository.findByNickname("NICKNAME");
+    Optional<Profile> createdUser = userRepository.findByNickname("NICKNAME");
 
     //then
-    assertEquals(user, createdUser.get());
-    assertNotNull(createdUser.get().getPublicId());
+    assertTrue(createdUser.isPresent());
+    assertEquals("NICKNAME", createdUser.get().getNickname());
+    assertNotNull(createdUser.get().getUser().getPublicId());
+    assertEquals(user.getId(), createdUser.get().getId());
   }
 
   @Transactional
@@ -41,11 +43,11 @@ class UserRepositoryTest {
 
     //when
     user.remove();
-    Optional<User> savedUser = userRepository.findByNickname("NICKNAME");
+    Optional<Profile> removedUser = userRepository.findByNickname("NICKNAME");
 
     //then
     assertNotNull(user.getDeletedAt());
-    assertTrue(savedUser.isEmpty());
+    assertTrue(removedUser.isEmpty());
   }
 
 }

--- a/src/test/java/com/run_us/server/domains/user/domain/UserTest.java
+++ b/src/test/java/com/run_us/server/domains/user/domain/UserTest.java
@@ -5,15 +5,9 @@ import static org.junit.jupiter.api.Assertions.*;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.core.parameters.P;
 
-@SpringBootTest
 class UserTest {
-
-  @Autowired
-  private UserFixtures userFixtures;
 
   private static final String URL_FIXTURE = "img_URL";
 
@@ -21,7 +15,7 @@ class UserTest {
   @Test
   @DisplayName("User 객체 생성 테스트")
   void create_user() {
-    User user = userFixtures.getDefaultUserWithNickname("nickname");
+    User user = UserFixtures.getDefaultUserWithNickname("nickname");
     assertEquals(user.getProfile().getNickname(), "nickname");
     assertEquals(user.getProfile().getBirthDate(), UserFixtures.DEFAULT_BIRTH_DATE);
   }
@@ -30,7 +24,7 @@ class UserTest {
   @DisplayName("User 프로필 이미지 변경")
   void change_user_profile_img_url() {
     //given
-    User user = userFixtures.getDefaultUser();
+    User user = UserFixtures.getDefaultUser();
     Profile profile = new Profile().builder().imgUrl(URL_FIXTURE).build();
     String expectedImgUrl = URL_FIXTURE;
     //when
@@ -44,7 +38,7 @@ class UserTest {
   @DisplayName("User soft delete")
   void remove_user() {
     //given
-    User user = userFixtures.getDefaultUser();
+    User user = UserFixtures.getDefaultUser();
 
     //when
     user.remove();

--- a/src/test/java/com/run_us/server/domains/user/domain/UserTest.java
+++ b/src/test/java/com/run_us/server/domains/user/domain/UserTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.security.core.parameters.P;
 
 class UserTest {
 
@@ -15,8 +16,8 @@ class UserTest {
   @DisplayName("User 객체 생성 테스트")
   void create_user() {
     User user = UserFixtures.getDefaultUserWithNickname("nickname");
-    assertEquals(user.getNickname(), "nickname");
-    assertEquals(user.getBirthDate(), UserFixtures.DEFAULT_BIRTH_DATE);
+    assertEquals(user.getProfile().getNickname(), "nickname");
+    assertEquals(user.getProfile().getBirthDate(), UserFixtures.DEFAULT_BIRTH_DATE);
   }
 
   @MethodSource("provideChangeUserProfileImgUrl")
@@ -24,12 +25,13 @@ class UserTest {
   void change_user_profile_img_url() {
     //given
     User user = UserFixtures.getDefaultUser();
+    Profile profile = new Profile().builder().imgUrl(URL_FIXTURE).build();
     String expectedImgUrl = URL_FIXTURE;
     //when
-    user.changeProfileImgUrl(expectedImgUrl);
+    user.setProfile(profile);
 
     //then
-    assertEquals(user.getImgUrl(), expectedImgUrl);
+    assertEquals(user.getProfile().getImgUrl(), expectedImgUrl);
   }
 
   @Test

--- a/src/test/java/com/run_us/server/domains/user/domain/UserTest.java
+++ b/src/test/java/com/run_us/server/domains/user/domain/UserTest.java
@@ -5,9 +5,15 @@ import static org.junit.jupiter.api.Assertions.*;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.core.parameters.P;
 
+@SpringBootTest
 class UserTest {
+
+  @Autowired
+  private UserFixtures userFixtures;
 
   private static final String URL_FIXTURE = "img_URL";
 
@@ -15,7 +21,7 @@ class UserTest {
   @Test
   @DisplayName("User 객체 생성 테스트")
   void create_user() {
-    User user = UserFixtures.getDefaultUserWithNickname("nickname");
+    User user = userFixtures.getDefaultUserWithNickname("nickname");
     assertEquals(user.getProfile().getNickname(), "nickname");
     assertEquals(user.getProfile().getBirthDate(), UserFixtures.DEFAULT_BIRTH_DATE);
   }
@@ -24,7 +30,7 @@ class UserTest {
   @DisplayName("User 프로필 이미지 변경")
   void change_user_profile_img_url() {
     //given
-    User user = UserFixtures.getDefaultUser();
+    User user = userFixtures.getDefaultUser();
     Profile profile = new Profile().builder().imgUrl(URL_FIXTURE).build();
     String expectedImgUrl = URL_FIXTURE;
     //when
@@ -38,7 +44,7 @@ class UserTest {
   @DisplayName("User soft delete")
   void remove_user() {
     //given
-    User user = UserFixtures.getDefaultUser();
+    User user = userFixtures.getDefaultUser();
 
     //when
     user.remove();


### PR DESCRIPTION
### 연관된 이슈를 적어주세요 📌

### 작업한 내용을 설명해주세요 ✔️

- ERD에 맞추어 (많은 클래스의) 타입 수정
  - id는 모두 Integer
  - public_id는 char(13)
- 유저, 프로필 테이블을 가져오기 위해 급히 프로필 분리
  - 테스트 코드도 이에 맞게 프로필과 유저 객체 활용하도록 적용
- DateAudit을 상황에 따라 분리(create_at only, 기존 2가지)

### 트러블 슈팅

### 리뷰어에게 하고 싶은 말을 적어주세요

- 사실 유저에서 프로필 요소를 바로 쓰고싶었으나 제 JPA 실력이 부족하여 OneToOne을 썼읍니다... 나는 필요하다. 좋은 방법.
- 아마 코드 건든게 많아서 충돌은 많이 날텐데, 타입변환만 잘 맞춰주면 로직상 이슈는 (아마)(거의) 없을겁니다.

### 확인하기

- [x] : 코드에 에러가 없는지 확인했나요?
- [x] : PR에 설명을 기재했나요?
- [x] : PR 태그를 붙였나요?
- [x] : 불필요한 로그나 `System.out`을 제거했나요?