### PR TITLE
[Refactor/running-dto-and-controller] - refactor running controller

### DIFF
--- a/src/main/java/com/run_us/server/domains/running/controller/RunningController.java
+++ b/src/main/java/com/run_us/server/domains/running/controller/RunningController.java
@@ -10,6 +10,7 @@ import com.run_us.server.domains.running.service.model.PersonalRecordQueryResult
 import com.run_us.server.global.common.SuccessResponse;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Slf4j
 @RestController
 @RequestMapping("/runnings")
 @RequiredArgsConstructor
@@ -27,12 +29,15 @@ public class RunningController {
 
   @PostMapping
   public SuccessResponse<RunningCreateResponse> createRunning(@RequestBody RunningCreateRequest runningCreateDto) {
+    //TODO: HTTP request 에서 userId를 추출 기능개발
+    log.info("action=create_running");
     return SuccessResponse.of(RunningHttpResponseCode.RUNNING_CREATED,
         runningPreparationService.createRunning(runningCreateDto));
   }
 
   @GetMapping("/{runningId}/participants")
   public SuccessResponse<List<JoinedParticipant>> joinedParticipants(@PathVariable String runningId) {
+    log.info("action=joined_participants running_id={}", runningId);
     List<JoinedParticipant> joinedParticipants = runningPreparationService.getJoinedParticipants(
         runningId);
     return SuccessResponse.of(RunningHttpResponseCode.PARTICIPANTS_FETCHED, joinedParticipants);
@@ -45,6 +50,7 @@ public class RunningController {
    * */
   @GetMapping("/{runningId}/records/{userId}")
   public SuccessResponse<PersonalRecordQueryResult> getPersonalRecord(@PathVariable String runningId, @PathVariable String userId) {
+    log.info("action=get_personal_record running_id={} user_id={}", runningId, userId);
     return SuccessResponse.of(RunningHttpResponseCode.SINGLE_RECORD_FETCHED,
         runningResultService.getPersonalRecord(runningId, userId));
   }

--- a/src/main/java/com/run_us/server/domains/running/controller/RunningSocketController.java
+++ b/src/main/java/com/run_us/server/domains/running/controller/RunningSocketController.java
@@ -41,7 +41,7 @@ public class RunningSocketController {
 
   /**
    * 러닝 시작
-   *
+   * @param userId 사용자 (고유번호 세션에서 추출)
    * @param requestDto 요청 body
    */
   @MessageMapping("/runnings/start")
@@ -54,7 +54,7 @@ public class RunningSocketController {
 
   /**
    * 위치 전송, 라이브 러닝방에 위치정보를 publish
-   *
+   * @param userId 사용자 (고유번호 세션에서 추출)
    * @param requestDto 요청 body
    */
   @MessageMapping("/users/runnings/location")
@@ -73,7 +73,8 @@ public class RunningSocketController {
 
   /***
    * 러닝 일시정지, 라이브 러닝방에 일시정지 이벤트를 publish
-   * @param requestDto
+   * @param userId 사용자 (고유번호 세션에서 추출)
+   * @param requestDto 요청 body
    */
   @MessageMapping("/users/runnings/pause")
   public void pauseRunning(@UserId String userId, RunningRequest.PauseRunning requestDto) {
@@ -86,10 +87,11 @@ public class RunningSocketController {
 
   /***
    * 러닝 재개, 라이브 러닝방에 재개 이벤트를 publish
-   * @param requestDto
+   * @param userId 사용자 (고유번호 세션에서 추출)
+   * @param requestDto 요청 body
    */
   @MessageMapping("/users/runnings/resume")
-  public void resumeRunning(@UserId String userId, RunningRequest.ResumeRunning requestDto, SimpMessageHeaderAccessor message) {
+  public void resumeRunning(@UserId String userId, RunningRequest.ResumeRunning requestDto) {
     log.info("resumeRunning : {}", requestDto.getRunningId());
     runningLiveService.resumeRunning(requestDto.getRunningId(), userId);
     simpMessagingTemplate.convertAndSend(
@@ -99,7 +101,8 @@ public class RunningSocketController {
 
   /***
    * 러닝 종료, 라이브 러닝방에 종료 이벤트를 publish
-   * @param requestDto
+   * @param userId 사용자 (고유번호 세션에서 추출)
+   * @param requestDto 요청 body
    */
   @MessageMapping("/users/runnings/end")
   public void endRunning(@UserId String userId,  RunningRequest.StopRunning requestDto) {
@@ -115,7 +118,7 @@ public class RunningSocketController {
    * 러닝 결과 집계, 결과를 저장하고 라이브 러닝방에 결과를 publish
    * @param sessionId 세션 ID (웹소켓 세션)
    * @param userId 사용자 (고유번호 세션에서 추출)
-   * @param requestDto
+   * @param requestDto 요청 body
    */
   @MessageMapping("/users/runnings/aggregate")
   public void aggregateRunning(

--- a/src/main/java/com/run_us/server/domains/running/controller/RunningSocketController.java
+++ b/src/main/java/com/run_us/server/domains/running/controller/RunningSocketController.java
@@ -129,16 +129,6 @@ public class RunningSocketController {
             sessionId, USER_WS_LOGS_SUBSCRIBE_PATH, SuccessResponse.messageOnly(RunningSocketResponseCode.END_RUNNING));
   }
 
-  /***
-   * 사용자의 요청메세지에서 subscribeId를 추출
-   * @param message
-   * @return
-   */
-  private String getSubscriptionId(Message<?> message) {
-    SimpMessageHeaderAccessor headerAccessor = SimpMessageHeaderAccessor.wrap(message);
-    return headerAccessor.getSubscriptionId();
-  }
-
   private void sendToUser(@NotNull String sessionId, @NotNull String destination, Object payload) {
     SimpMessageHeaderAccessor headerAccessor =
         SimpMessageHeaderAccessor.create(SimpMessageType.MESSAGE);

--- a/src/main/java/com/run_us/server/domains/running/controller/aop/UserId.java
+++ b/src/main/java/com/run_us/server/domains/running/controller/aop/UserId.java
@@ -5,6 +5,11 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/***
+ * [중요] : STOMP 에서만 사용할 수 있습니다.
+ * 사용자 고유번호를 추출하기 위한 어노테이션
+ * STOMP 헤더에서 유저 정보를 추출하기 위해 사용
+ * */
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface UserId {}

--- a/src/main/java/com/run_us/server/domains/running/controller/aop/UserId.java
+++ b/src/main/java/com/run_us/server/domains/running/controller/aop/UserId.java
@@ -1,0 +1,10 @@
+package com.run_us.server.domains.running.controller.aop;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface UserId {}

--- a/src/main/java/com/run_us/server/domains/running/controller/aop/UserIdArgumentResolver.java
+++ b/src/main/java/com/run_us/server/domains/running/controller/aop/UserIdArgumentResolver.java
@@ -1,0 +1,28 @@
+package com.run_us.server.domains.running.controller.aop;
+
+import com.run_us.server.domains.user.domain.User;
+import org.springframework.core.MethodParameter;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.handler.invocation.HandlerMethodArgumentResolver;
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
+import org.springframework.stereotype.Component;
+
+import java.util.Objects;
+
+import static com.run_us.server.global.common.GlobalConst.SESSION_ATTRIBUTE_USER;
+
+@Component
+public class UserIdArgumentResolver implements HandlerMethodArgumentResolver {
+
+  @Override
+  public boolean supportsParameter(MethodParameter parameter) {
+    return parameter.getParameterAnnotation(UserId.class) != null;
+  }
+
+  @Override
+  public Object resolveArgument(MethodParameter parameter, Message<?> message) throws Exception {
+    SimpMessageHeaderAccessor headerAccessor = SimpMessageHeaderAccessor.wrap(message);
+    User user = (User) Objects.requireNonNull(headerAccessor.getSessionAttributes()).get(SESSION_ATTRIBUTE_USER);
+    return user.getPublicId();
+  }
+}

--- a/src/main/java/com/run_us/server/domains/running/controller/model/request/RunningRequest.java
+++ b/src/main/java/com/run_us/server/domains/running/controller/model/request/RunningRequest.java
@@ -9,20 +9,16 @@ import lombok.ToString;
 public class RunningRequest {
 
     /**
-     * 러닝 시작 dto (프로토타입용 임시 dto)
+     * 러닝 시작 dto
      */
     @Getter
     @ToString
     public static class StartRunning {
-        private String userId;
-        private String runningId;
-        private String runningKey;
+        private final String runningId;
 
         @Builder
-        public StartRunning(String userId, String runningId, String runningKey) {
-            this.userId = userId;
+        public StartRunning(String runningId) {
             this.runningId = runningId;
-            this.runningKey = runningKey;
         }
     }
     // DTO e다 분리 / inner class
@@ -34,15 +30,13 @@ public class RunningRequest {
     @ToString
     public static class LocationUpdate {
         private final String runningId;
-        private final String userId; // TODO : 추후 User 쪽에 간단한 프로필 응답 response dto 만들어서 넣기
         private final Float latitude;
         private final Float longitude;
         private final int count;
 
         @Builder
-        public LocationUpdate(final String runningId, final String userId, final Float latitude, final Float longitude, final int count) {
+        public LocationUpdate(final String runningId, final Float latitude, final Float longitude, final int count) {
             this.runningId = runningId;
-            this.userId = userId;
             this.latitude = latitude;
             this.longitude = longitude;
             this.count = count;
@@ -53,13 +47,11 @@ public class RunningRequest {
     @ToString
     public static class PauseRunning {
        private final String runningId;
-       private final String userId;
        private final int count;
 
        @Builder
-        public PauseRunning(final String runningKey, final String userKey, final int count) {
+        public PauseRunning(final String runningKey, final int count) {
             this.runningId = runningKey;
-            this.userId = userKey;
             this.count = count;
         }
     }
@@ -69,13 +61,11 @@ public class RunningRequest {
     public static final class ResumeRunning {
 
         private final String runningId;
-        private final String userId;
         private final int count;
 
         @Builder
-        public ResumeRunning(final String runningId, final String userId, final int count) {
+        public ResumeRunning(final String runningId, final int count) {
             this.runningId = runningId;
-            this.userId = userId;
             this.count = count;
         }
     }
@@ -84,13 +74,11 @@ public class RunningRequest {
     public static class StopRunning {
 
         private final String runningId;
-        private final String userId;
         private final int count;
 
         @Builder
-        public StopRunning(final String runningId, final String userId, final int count) {
+        public StopRunning(final String runningId, final int count) {
             this.runningId = runningId;
-            this.userId = userId;
             this.count = count;
         }
     }
@@ -99,7 +87,6 @@ public class RunningRequest {
     public static class AggregateRunning {
 
         private final String runningId;
-        private final String userId;
         private final List<LocationData> dataList;
         private final int count;
         private final int runningDistanceInMeter;
@@ -109,14 +96,12 @@ public class RunningRequest {
         @Builder
         public AggregateRunning(
                 final String runningId,
-                final String userId,
                 final int count,
                 final List<LocationData> dataList,
                 final int runningDistanceInMeter,
                 final int runningDurationInMilliSecond,
                 final int averagePaceInMilliSecond) {
             this.runningId = runningId;
-            this.userId = userId;
             this.count = count;
             this.dataList = dataList;
             this.runningDistanceInMeter = runningDistanceInMeter;

--- a/src/main/java/com/run_us/server/domains/running/controller/model/response/RunningResponse.java
+++ b/src/main/java/com/run_us/server/domains/running/controller/model/response/RunningResponse.java
@@ -41,9 +41,9 @@ public class RunningResponse {
             this.y = y;
         }
 
-        public static LocationData toDto(LocationUpdate data) {
+        public static LocationData toDto(LocationUpdate data, String userId) {
             return LocationData.builder()
-                    .userKey(data.getUserId())
+                    .userKey(userId)
                     .x(data.getLatitude())
                     .y(data.getLongitude())
                     .build();

--- a/src/main/java/com/run_us/server/domains/running/service/RunningResultService.java
+++ b/src/main/java/com/run_us/server/domains/running/service/RunningResultService.java
@@ -29,13 +29,15 @@ public class RunningResultService {
   /***
    * 러닝 개인 기록 저장
    * @param runningId 러닝 고유번호(public)
-   * @param user 요청 유저
+   * @param userId 요청 유저 고유번호(public)
    * @param aggregation 러닝 데이터 결과
    */
   @Transactional
-  public void savePersonalRecord(String runningId, User user, RunningAggregation aggregation) {
+  public void savePersonalRecord(String runningId, String userId, RunningAggregation aggregation) {
     Running running = runningRepository.findByPublicKey(runningId)
         .orElseThrow(() -> RunningException.of(RunningErrorCode.RUNNING_NOT_FOUND));
+    User user = userRepository.findByPublicId(userId)
+        .orElseThrow(IllegalArgumentException::new);
     PersonalRecord personalRecord = RunningMapper.toPersonalRecord(running.getId(), user.getId(), aggregation);
     personalRecordRepository.save(personalRecord);
   }

--- a/src/main/java/com/run_us/server/global/config/WebSocketConfig.java
+++ b/src/main/java/com/run_us/server/global/config/WebSocketConfig.java
@@ -1,13 +1,18 @@
 package com.run_us.server.global.config;
 
+import com.run_us.server.domains.running.controller.aop.UserIdArgumentResolver;
 import com.run_us.server.global.exception.StompErrorHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+
+import org.springframework.messaging.handler.invocation.HandlerMethodArgumentResolver;
 import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+import java.util.List;
 
 import static com.run_us.server.global.common.SocketConst.*;
 
@@ -21,6 +26,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     private final StompInterceptor stompInterceptor;
     private final StompErrorHandler stompErrorHandler;
+    private final UserIdArgumentResolver userIdArgumentResolver;
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
@@ -39,5 +45,10 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     @Override
     public void configureClientInboundChannel(ChannelRegistration registration) {
         registration.interceptors(stompInterceptor);
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> argumentResolvers) {
+        argumentResolvers.add(userIdArgumentResolver);
     }
 }


### PR DESCRIPTION
### 연관된 이슈를 적어주세요 📌
#38 #40 

### 작업한 내용을 설명해주세요 ✔️

- **Request DTO에 SPEC 반영 및 불필요한 유저 아이디 필드 삭제**
- **로깅 형식 변경**
```
    log.info("action=update_running user_id={} running_id={}", userId, requestDto.getRunningId());

```
![Screenshot 2024-10-30 at 12 59 23 AM](https://github.com/user-attachments/assets/f0f7df49-8b0d-4dc3-9397-751d38d1f611)

- **STOMP 헤더에서 유저 정보를 추출하여 컨트롤러 메소드 파라매터로 주입하는 로직 작성**

### 트러블 슈팅
- 유저 정보 (user public Id)를 조회하는 로직의 경우 **관심사의 분리**로 처리가능하다고 생각했습니다.
AOP 경험이 적어 여러가지를 시도하다 **Resolver을 통한 주입**으로 해결했습니다. 
[스프링MVC에서의 예시](https://www.baeldung.com/spring-mvc-custom-data-binder)
[웹소켓에서 적용](https://velog.io/@eora21/Spring-Websocket-Websocket-Security-%EB%A7%9B%EA%B9%94%EB%82%98%EA%B2%8C-%EC%82%AC%EC%9A%A9%ED%95%B4%EB%B3%B4%EA%B8%B0)
그냥 mvc와 비슷하게 WebsocketConfig에서 add해주면됩니다.
### 리뷰어에게 하고 싶은 말을 적어주세요
- 나중에 로그 처리, 분석에서 **key-value**를 사용하는 것이 좋을 것 같아 로깅 형식을 바꿨습니다 :) 의견남겨주세요
- 이제 User 정보 조회를 위한 복잡한 코드가 사라졌습니다. AOP!
</br>

### [추후 PR에서 개발할 것들]
- 응답 DTO 적용 : 이 부분은 서비스 로직이 변경될 확률이 높아 요구사항을 반영하는 다른 PR에서 적용하겠습니다.
- #40 에 언급한 웹소켓 500 에러 핸들링
- HTTP 일반 API에서 유저정보를 가져오는 로직 (시큐리티를 통한 구현)

### 확인하기

- [x] : 코드에 에러가 없는지 확인했나요?
- [x] : PR에 설명을 기재했나요?
- [x] : PR 태그를 붙였나요?
- [x] : 불필요한 로그나 `System.out`을 제거했나요?