### PR TITLE
[Feat/update running domain] - 러닝 도메인 재작성

### DIFF
--- a/src/main/java/com/run_us/server/domains/running/exception/RunningErrorCode.java
+++ b/src/main/java/com/run_us/server/domains/running/exception/RunningErrorCode.java
@@ -8,7 +8,10 @@ public enum RunningErrorCode implements CustomResponseCode {
   RUNNING_NOT_FOUND("RE001", "Running not found", "Running not found", HttpStatus.NOT_FOUND),
   AGGREGATE_FAILED("RE4001", "Failed to Save Running Result", "Failed to Save Running Result",
       HttpStatus.BAD_REQUEST),
-  PERSONAL_RECORD_NOT_FOUND("REH4001", "Personal Record not found", "Personal Record not found", HttpStatus.BAD_REQUEST);
+  PERSONAL_RECORD_NOT_FOUND("REH4001", "Personal Record not found", "Personal Record not found", HttpStatus.BAD_REQUEST),
+  USER_NOT_JOINED("REH4002", "User not joined to Run", "User not joined to Run", HttpStatus.BAD_REQUEST),
+  RUNNING_ALREADY_FINISHED("REH4003", "Running Already Finished", "Running Already Finished", HttpStatus.BAD_REQUEST),
+  RUNNING_CANCELED("REH4004", "Running Already Canceled", "Running Already Canceled", HttpStatus.BAD_REQUEST),;
 
 
   private final String code;

--- a/src/main/java/com/run_us/server/v2/RunningException.java
+++ b/src/main/java/com/run_us/server/v2/RunningException.java
@@ -1,0 +1,19 @@
+package com.run_us.server.v2;
+
+import com.run_us.server.global.exception.BusinessException;
+import com.run_us.server.global.exception.code.CustomResponseCode;
+
+public class RunningException extends BusinessException {
+
+  protected RunningException(CustomResponseCode errorCode) {
+    super(errorCode);
+  }
+
+  protected RunningException(CustomResponseCode errorCode, String logMessage) {
+    super(errorCode, logMessage);
+  }
+
+  public static RunningException of(CustomResponseCode errorCode) {
+    return new RunningException(errorCode);
+  }
+}

--- a/src/main/java/com/run_us/server/v2/RunningHttpResponseCode.java
+++ b/src/main/java/com/run_us/server/v2/RunningHttpResponseCode.java
@@ -1,0 +1,46 @@
+package com.run_us.server.v2;
+
+import com.run_us.server.global.exception.code.CustomResponseCode;
+import org.springframework.http.HttpStatus;
+
+public enum RunningHttpResponseCode implements CustomResponseCode {
+  RUNNING_CREATED("RSH2001", "러닝 생성 성공", "러닝 생성 성공"),
+  PARTICIPANTS_FETCHED("RSH2002", "러닝 참여자 조회 성공", "러닝 참여자 조회 성공"),
+  SINGLE_RECORD_SAVED("RSH2003", "싱글런 기록 저장 성공", "싱글런 기록 저장 성공"),
+  ROOM_ID_FETCHED("RSH2004", "대기방 ID 조회 성공", "Passcode Translation 성공"),
+  SINGLE_RECORD_FETCHED("RSH2005", "단일 러닝 기록 상세 조회 성공", "단일 러닝 기록 상세 조회 성공"),
+  RUNNING_DELETED("RSH2006", "러닝 삭제 성공", "러닝 삭제 성공"),
+  GROUP_RECORD_SAVED("RSH2007", "그룹런 기록 저장 성공", "그룹런 기록 저장 성공"),
+  RUN_PREVIEW_FETCHED("RSH2008", "러닝 세션글 조회 성공", "러닝 세션글 조회 성공"),
+  RUN_PREVIEW_CREATED("RSH2009", "러닝 세션글 수정 성공", "러닝 세션글 수정 성공");
+
+  private final String code;
+  private final String clientMessage;
+  private final String logMessage;
+
+  RunningHttpResponseCode(String code, String clientMessage, String logMessage) {
+    this.code = code;
+    this.clientMessage = clientMessage;
+    this.logMessage = logMessage;
+  }
+
+  @Override
+  public String getCode() {
+    return this.code;
+  }
+
+  @Override
+  public String getClientMessage() {
+    return this.clientMessage;
+  }
+
+  @Override
+  public String getLogMessage() {
+    return this.logMessage;
+  }
+
+  @Override
+  public HttpStatus getHttpStatusCode() {
+    return null;
+  }
+}

--- a/src/main/java/com/run_us/server/v2/running/run/controller/RunController.java
+++ b/src/main/java/com/run_us/server/v2/running/run/controller/RunController.java
@@ -1,7 +1,7 @@
 package com.run_us.server.v2.running.run.controller;
 
-import com.run_us.server.domains.running.controller.model.RunningHttpResponseCode;
 import com.run_us.server.global.common.SuccessResponse;
+import com.run_us.server.v2.RunningHttpResponseCode;
 import com.run_us.server.v2.running.run.controller.model.request.SessionRunCreateRequest;
 import com.run_us.server.v2.running.run.service.model.ParticipantInfo;
 import com.run_us.server.v2.running.run.service.model.RunCreateResponse;

--- a/src/main/java/com/run_us/server/v2/running/run/controller/RunController.java
+++ b/src/main/java/com/run_us/server/v2/running/run/controller/RunController.java
@@ -1,0 +1,51 @@
+package com.run_us.server.v2.running.run.controller;
+
+import com.run_us.server.domains.running.controller.model.RunningHttpResponseCode;
+import com.run_us.server.global.common.SuccessResponse;
+import com.run_us.server.v2.running.run.controller.model.request.SessionRunCreateRequest;
+import com.run_us.server.v2.running.run.service.model.ParticipantInfo;
+import com.run_us.server.v2.running.run.service.model.RunCreateResponse;
+import com.run_us.server.v2.running.run.service.usecase.RunCreateUseCase;
+import com.run_us.server.v2.running.run.service.usecase.RunRegisterUseCase;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+//임시로 /runs로 변경
+@RequestMapping("/runs")
+@RequiredArgsConstructor
+public class RunController {
+
+  private final RunCreateUseCase runCreateUseCase;
+  private final RunRegisterUseCase runRegisterUseCase;
+
+  @PostMapping(params = "mode=custom")
+  public SuccessResponse<RunCreateResponse> createCustomRun(
+      @RequestAttribute("publicUserId") String userId) {
+    log.info("action=create_custom_running user_id={}", userId);
+    return SuccessResponse.of(
+        RunningHttpResponseCode.RUNNING_CREATED, runCreateUseCase.saveNewCustomRun(userId));
+  }
+
+  @PostMapping(params = "mode=normal")
+  public SuccessResponse<RunCreateResponse> createNormalRun(
+      @RequestBody SessionRunCreateRequest runningCreateRequest,
+      @RequestAttribute("publicUserId") String userId) {
+    log.info("action=create_session_running user_id={}", userId);
+    return SuccessResponse.of(
+        RunningHttpResponseCode.RUNNING_CREATED,
+        runCreateUseCase.saveNewSessionRun(
+            userId, runningCreateRequest.toRunningPreview()));
+  }
+
+  @GetMapping("/{runningId}/participants")
+  public SuccessResponse<List<ParticipantInfo>> joinedParticipants(@PathVariable String runningId) {
+    log.info("action=joined_participants running_id={}", runningId);
+    List<ParticipantInfo> joinedParticipants = runRegisterUseCase.getRunParticipants(runningId);
+    return SuccessResponse.of(RunningHttpResponseCode.PARTICIPANTS_FETCHED, joinedParticipants);
+  }
+
+}

--- a/src/main/java/com/run_us/server/v2/running/run/controller/RunPreviewController.java
+++ b/src/main/java/com/run_us/server/v2/running/run/controller/RunPreviewController.java
@@ -1,0 +1,28 @@
+package com.run_us.server.v2.running.run.controller;
+
+import com.run_us.server.global.common.SuccessResponse;
+import com.run_us.server.v2.RunningHttpResponseCode;
+import com.run_us.server.v2.running.run.service.model.GetRunPreviewResponse;
+import com.run_us.server.v2.running.run.service.usecase.RunPreviewUseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/runnings/previews")
+@RequiredArgsConstructor
+public class RunPreviewController {
+
+  private final RunPreviewUseCase runPreviewUseCase;
+
+  @GetMapping("/{runId}")
+  public SuccessResponse<GetRunPreviewResponse> getRunPreview(@RequestParam Integer runId) {
+    log.info("action=get_run_preview");
+    return SuccessResponse.of(
+        RunningHttpResponseCode.RUN_PREVIEW_FETCHED, runPreviewUseCase.getRunPreview(runId));
+  }
+}

--- a/src/main/java/com/run_us/server/v2/running/run/controller/model/request/SessionRunCreateRequest.java
+++ b/src/main/java/com/run_us/server/v2/running/run/controller/model/request/SessionRunCreateRequest.java
@@ -1,0 +1,44 @@
+package com.run_us.server.v2.running.run.controller.model.request;
+
+import com.run_us.server.v2.running.run.domain.RunPace;
+import com.run_us.server.v2.running.run.domain.RunningPreview;
+import java.time.ZonedDateTime;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class SessionRunCreateRequest {
+  private final String title;
+  private final String description;
+  private final ZonedDateTime beginTime;
+  private final String meetingPoint;
+  private final String goal;
+  private final String accessLevel;
+  private final List<String> exposingCrews;
+  private final RunPace paceTag;
+
+  @Builder
+  public SessionRunCreateRequest(String title, String description, ZonedDateTime beginTime, String meetingPoint, String goal, String accessLevel, List<String> exposingCrews, RunPace paceTag) {
+    this.title = title;
+    this.description = description;
+    this.beginTime = beginTime;
+    this.meetingPoint = meetingPoint;
+    this.goal = goal;
+    this.accessLevel = accessLevel;
+    this.exposingCrews = exposingCrews;
+    this.paceTag = paceTag;
+  }
+
+  public RunningPreview toRunningPreview() {
+    return RunningPreview.builder()
+        .title(title)
+        .description(description)
+        .beginTime(beginTime)
+        .meetingPoint(meetingPoint)
+        .goal(goal)
+        .accessLevel(accessLevel)
+        .paceTag(paceTag)
+        .build();
+  }
+}

--- a/src/main/java/com/run_us/server/v2/running/run/domain/Participant.java
+++ b/src/main/java/com/run_us/server/v2/running/run/domain/Participant.java
@@ -1,0 +1,28 @@
+package com.run_us.server.v2.running.run.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Participant {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  private Integer userId;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "run_id")
+  private Run run;
+
+  private boolean isAttended;
+
+  public Participant(Integer userId, Run run) {
+    this.userId = userId;
+    this.run = run;
+    this.isAttended = false;
+  }
+}

--- a/src/main/java/com/run_us/server/v2/running/run/domain/Run.java
+++ b/src/main/java/com/run_us/server/v2/running/run/domain/Run.java
@@ -1,0 +1,66 @@
+package com.run_us.server.v2.running.run.domain;
+
+import com.run_us.server.domains.running.exception.RunningErrorCode;
+import com.run_us.server.global.common.CreationTimeAudit;
+import com.run_us.server.v2.RunningException;
+import io.hypersistence.tsid.TSID;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "run")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Run extends CreationTimeAudit {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "run_id")
+  private Integer id;
+
+  private Integer hostId;
+
+  private String publicId;
+
+  private String passcode;
+
+  @Enumerated(EnumType.STRING)
+  private RunStatus status;
+
+  @Embedded private RunningPreview preview;
+
+  // 생성
+  public Run(Integer hostId) {
+    this.hostId = hostId;
+    this.status = RunStatus.WAITING;
+  }
+
+  @Override
+  public void prePersist() {
+    this.publicId = TSID.Factory.getTsid().toString();
+  }
+
+  // 수정
+  public void changeStatus(RunStatus status) {
+    validateRunModifiable();
+    this.status = status;
+  }
+
+  public void modifySessionInfo(RunningPreview runningPreview) {
+    validateRunModifiable();
+    this.preview = runningPreview;
+  }
+
+  public boolean isHost(int userId) {
+    return this.hostId == userId;
+  }
+
+  private void validateRunModifiable() {
+    if (this.status == RunStatus.FINISHED)
+      throw RunningException.of(RunningErrorCode.RUNNING_ALREADY_FINISHED);
+    if (this.status == RunStatus.CANCELLED)
+      throw RunningException.of(RunningErrorCode.RUNNING_CANCELED);
+  }
+}

--- a/src/main/java/com/run_us/server/v2/running/run/domain/RunPace.java
+++ b/src/main/java/com/run_us/server/v2/running/run/domain/RunPace.java
@@ -1,0 +1,13 @@
+package com.run_us.server.v2.running.run.domain;
+
+public enum RunPace {
+  PACE_UNDER_500,
+  PACE_500,
+  PACE_530,
+  PACE_600,
+  PACE_630,
+  PACE_700,
+  PACE_730,
+  PACE_800,
+  PACE_WALKING
+}

--- a/src/main/java/com/run_us/server/v2/running/run/domain/RunStatus.java
+++ b/src/main/java/com/run_us/server/v2/running/run/domain/RunStatus.java
@@ -1,0 +1,8 @@
+package com.run_us.server.v2.running.run.domain;
+
+public enum RunStatus {
+  WAITING,
+  RUNNING,
+  CANCELLED,
+  FINISHED
+}

--- a/src/main/java/com/run_us/server/v2/running/run/domain/RunningPreview.java
+++ b/src/main/java/com/run_us/server/v2/running/run/domain/RunningPreview.java
@@ -1,0 +1,40 @@
+package com.run_us.server.v2.running.run.domain;
+
+import jakarta.persistence.Embeddable;
+import java.io.Serializable;
+import java.time.ZonedDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RunningPreview implements Serializable {
+  private String title;
+  private String description;
+  private String meetingPoint;
+  private RunPace paceTag;
+  private String goal;
+  private String accessLevel;
+  private ZonedDateTime beginTime;
+
+  @Builder
+  public RunningPreview(
+      String title,
+      String description,
+      String meetingPoint,
+      RunPace paceTag,
+      String goal,
+      String accessLevel,
+      ZonedDateTime beginTime) {
+    this.title = title;
+    this.description = description;
+    this.meetingPoint = meetingPoint;
+    this.paceTag = paceTag;
+    this.goal = goal;
+    this.accessLevel = accessLevel;
+    this.beginTime = beginTime;
+  }
+}

--- a/src/main/java/com/run_us/server/v2/running/run/repository/ParticipantRepository.java
+++ b/src/main/java/com/run_us/server/v2/running/run/repository/ParticipantRepository.java
@@ -1,0 +1,23 @@
+package com.run_us.server.v2.running.run.repository;
+
+import com.run_us.server.v2.running.run.domain.Participant;
+import com.run_us.server.v2.running.run.service.model.ParticipantInfo;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ParticipantRepository extends JpaRepository<Participant, Long> {
+
+  Optional<Participant> findByUserIdAndRunId(Integer userId, Integer runId);
+
+  @Query(
+      "SELECT new com.run_us.server.v2.running.run.service.model.ParticipantInfo("
+          + "u.profile.nickname, u.profile.imgUrl, u.profile.totalDistance) "
+          + "FROM Participant p "
+          + "join User u on p.userId = u.id "
+          + "WHERE p.run.id = :runId")
+  List<ParticipantInfo> findByRunId(Integer runId);
+}

--- a/src/main/java/com/run_us/server/v2/running/run/repository/RunRepository.java
+++ b/src/main/java/com/run_us/server/v2/running/run/repository/RunRepository.java
@@ -1,0 +1,21 @@
+package com.run_us.server.v2.running.run.repository;
+
+import com.run_us.server.v2.running.run.domain.Run;
+import com.run_us.server.v2.running.run.service.model.GetRunPreviewResponse;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RunRepository extends JpaRepository<Run, Integer> {
+  Optional<Run> findByPublicId(String publicId);
+
+  @Query(
+      "SELECT new com.run_us.server.v2.running.run.service.model.GetRunPreviewResponse"
+          + "(u.profile.nickname, u.profile.imgUrl, r.preview) "
+          + "FROM Run r "
+          + "left join User u on r.hostId = u.id "
+          + "WHERE r.id = :runId")
+  GetRunPreviewResponse findByRunId(Integer runId);
+}

--- a/src/main/java/com/run_us/server/v2/running/run/service/DateUtils.java
+++ b/src/main/java/com/run_us/server/v2/running/run/service/DateUtils.java
@@ -1,0 +1,18 @@
+package com.run_us.server.v2.running.run.service;
+
+import java.time.ZonedDateTime;
+
+public final class DateUtils {
+
+  public static ZonedDateTime getFirstDayOfThisWeek() {
+    return ZonedDateTime.now().minusDays(ZonedDateTime.now().getDayOfWeek().getValue() - 1);
+  }
+
+  public static ZonedDateTime getFirstDayOfThisMonth() {
+    return ZonedDateTime.now().minusDays(ZonedDateTime.now().getDayOfMonth() - 1);
+  }
+
+  public static ZonedDateTime getFirstDayOfThisYear() {
+    return ZonedDateTime.now().minusDays(ZonedDateTime.now().getDayOfYear() - 1);
+  }
+}

--- a/src/main/java/com/run_us/server/v2/running/run/service/ParticipantService.java
+++ b/src/main/java/com/run_us/server/v2/running/run/service/ParticipantService.java
@@ -1,0 +1,35 @@
+package com.run_us.server.v2.running.run.service;
+
+import com.run_us.server.domains.running.exception.RunningErrorCode;
+import com.run_us.server.v2.RunningException;
+import com.run_us.server.v2.running.run.domain.Participant;
+import com.run_us.server.v2.running.run.domain.Run;
+import com.run_us.server.v2.running.run.repository.ParticipantRepository;
+import com.run_us.server.v2.running.run.service.model.ParticipantInfo;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ParticipantService {
+
+  private final ParticipantRepository participantRepository;
+
+  public void registerParticipant(Integer userId, Run run) {
+    Participant participant = new Participant(userId, run);
+    participantRepository.save(participant);
+  }
+
+  public void cancelParticipant(Integer userId, Run run) {
+    Participant participant =
+        participantRepository
+            .findByUserIdAndRunId(userId, run.getId())
+            .orElseThrow(() -> RunningException.of(RunningErrorCode.USER_NOT_JOINED));
+    participantRepository.delete(participant);
+  }
+
+  public List<ParticipantInfo> getParticipants(Run run) {
+    return participantRepository.findByRunId(run.getId());
+  }
+}

--- a/src/main/java/com/run_us/server/v2/running/run/service/RunCommandService.java
+++ b/src/main/java/com/run_us/server/v2/running/run/service/RunCommandService.java
@@ -1,0 +1,35 @@
+package com.run_us.server.v2.running.run.service;
+
+import com.run_us.server.domains.user.domain.User;
+import com.run_us.server.v2.running.run.domain.Run;
+import com.run_us.server.v2.running.run.domain.RunStatus;
+import com.run_us.server.v2.running.run.domain.RunningPreview;
+import com.run_us.server.v2.running.run.repository.RunRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RunCommandService {
+
+  private final RunRepository runRepository;
+  private final RunValidator runValidator;
+  private final RunQueryService runQueryService;
+
+  public Run saveNewRun(User user, RunningPreview preview) {
+    Run run = new Run(user.getId());
+    run.modifySessionInfo(preview);
+    return runRepository.save(run);
+  }
+
+  public void updateRunPreview(Integer userId, Integer runId, RunningPreview preview) {
+    Run run = runQueryService.findByRunId(runId);
+    runValidator.validateIsRunOwner(userId, run);
+    run.modifySessionInfo(preview);
+  }
+
+  public void updateRunStatus(Integer runId, RunStatus updatedStatus) {
+    Run run = runQueryService.findByRunId(runId);
+    run.changeStatus(updatedStatus);
+  }
+}

--- a/src/main/java/com/run_us/server/v2/running/run/service/RunQueryService.java
+++ b/src/main/java/com/run_us/server/v2/running/run/service/RunQueryService.java
@@ -1,0 +1,32 @@
+package com.run_us.server.v2.running.run.service;
+
+import com.run_us.server.domains.running.exception.RunningErrorCode;
+import com.run_us.server.v2.RunningException;
+import com.run_us.server.v2.running.run.domain.Run;
+import com.run_us.server.v2.running.run.repository.RunRepository;
+import com.run_us.server.v2.running.run.service.model.GetRunPreviewResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RunQueryService {
+
+  private final RunRepository runRepository;
+
+  public Run findByRunId(Integer runId) {
+    return runRepository
+        .findById(runId)
+        .orElseThrow(() -> RunningException.of(RunningErrorCode.RUNNING_NOT_FOUND));
+  }
+
+  public Run findByRunPublicId(String runPublicId) {
+    return runRepository
+        .findByPublicId(runPublicId)
+        .orElseThrow(() -> RunningException.of(RunningErrorCode.RUNNING_NOT_FOUND));
+  }
+
+  public GetRunPreviewResponse getRunPreviewById(Integer runId) {
+    return runRepository.findByRunId(runId);
+  }
+}

--- a/src/main/java/com/run_us/server/v2/running/run/service/RunValidator.java
+++ b/src/main/java/com/run_us/server/v2/running/run/service/RunValidator.java
@@ -1,0 +1,15 @@
+package com.run_us.server.v2.running.run.service;
+
+import com.run_us.server.domains.running.exception.RunningErrorCode;
+import com.run_us.server.v2.RunningException;
+import com.run_us.server.v2.running.run.domain.Run;
+import org.springframework.stereotype.Component;
+
+@Component
+public final class RunValidator {
+  public void validateIsRunOwner(Integer userId, Run run) {
+    if (!run.isHost(userId)) {
+      throw RunningException.of(RunningErrorCode.RUNNING_NOT_FOUND);
+    }
+  }
+}

--- a/src/main/java/com/run_us/server/v2/running/run/service/model/GetRunPreviewResponse.java
+++ b/src/main/java/com/run_us/server/v2/running/run/service/model/GetRunPreviewResponse.java
@@ -1,0 +1,17 @@
+package com.run_us.server.v2.running.run.service.model;
+
+import com.run_us.server.v2.running.run.domain.RunningPreview;
+import lombok.Getter;
+
+@Getter
+public class GetRunPreviewResponse {
+  private final String hostName;
+  private final String hostImgUrl;
+  private final RunningPreview preview;
+
+  public GetRunPreviewResponse(String hostName, String hostImgUrl, RunningPreview preview) {
+    this.hostName = hostName;
+    this.hostImgUrl = hostImgUrl;
+    this.preview = preview;
+  }
+}

--- a/src/main/java/com/run_us/server/v2/running/run/service/model/ParticipantInfo.java
+++ b/src/main/java/com/run_us/server/v2/running/run/service/model/ParticipantInfo.java
@@ -1,0 +1,19 @@
+package com.run_us.server.v2.running.run.service.model;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ParticipantInfo {
+  private String name;
+  private String imgUrl;
+  private Integer totalDistanceInMeters;
+
+  public ParticipantInfo(String name, String imgUrl, Integer totalDistanceInMeters) {
+    this.name = name;
+    this.imgUrl = imgUrl;
+    this.totalDistanceInMeters = totalDistanceInMeters;
+  }
+}

--- a/src/main/java/com/run_us/server/v2/running/run/service/model/RunCreateResponse.java
+++ b/src/main/java/com/run_us/server/v2/running/run/service/model/RunCreateResponse.java
@@ -1,0 +1,19 @@
+package com.run_us.server.v2.running.run.service.model;
+
+import com.run_us.server.v2.running.run.domain.Run;
+import lombok.Getter;
+
+@Getter
+public class RunCreateResponse {
+  private final String runningId;
+  private final String passcode;
+
+  private RunCreateResponse(String runningId, String passcode) {
+    this.runningId = runningId;
+    this.passcode = passcode;
+  }
+
+  public static RunCreateResponse from(Run run) {
+    return new RunCreateResponse(run.getPublicId(), run.getPasscode());
+  }
+}

--- a/src/main/java/com/run_us/server/v2/running/run/service/usecase/RunCreateUseCase.java
+++ b/src/main/java/com/run_us/server/v2/running/run/service/usecase/RunCreateUseCase.java
@@ -1,0 +1,10 @@
+package com.run_us.server.v2.running.run.service.usecase;
+
+import com.run_us.server.v2.running.run.domain.RunningPreview;
+import com.run_us.server.v2.running.run.service.model.RunCreateResponse;
+
+public interface RunCreateUseCase {
+  RunCreateResponse saveNewCustomRun(String userId);
+
+  RunCreateResponse saveNewSessionRun(String userId, RunningPreview runningPreview);
+}

--- a/src/main/java/com/run_us/server/v2/running/run/service/usecase/RunCreateUseCaseImpl.java
+++ b/src/main/java/com/run_us/server/v2/running/run/service/usecase/RunCreateUseCaseImpl.java
@@ -1,0 +1,28 @@
+package com.run_us.server.v2.running.run.service.usecase;
+
+import com.run_us.server.domains.user.domain.User;
+import com.run_us.server.domains.user.service.UserService;
+import com.run_us.server.v2.running.run.domain.RunningPreview;
+import com.run_us.server.v2.running.run.service.RunCommandService;
+import com.run_us.server.v2.running.run.service.model.RunCreateResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RunCreateUseCaseImpl implements RunCreateUseCase {
+
+  private final RunCommandService runCommandService;
+  private final UserService userService;
+
+  public RunCreateResponse saveNewCustomRun(String userId) {
+    User user = userService.getUserByPublicId(userId);
+    return RunCreateResponse.from(runCommandService.saveNewRun(user, null));
+  }
+
+  @Override
+  public RunCreateResponse saveNewSessionRun(String userId, RunningPreview runningPreview) {
+    User user = userService.getUserByPublicId(userId);
+    return RunCreateResponse.from(runCommandService.saveNewRun(user, runningPreview));
+  }
+}

--- a/src/main/java/com/run_us/server/v2/running/run/service/usecase/RunPreviewUseCase.java
+++ b/src/main/java/com/run_us/server/v2/running/run/service/usecase/RunPreviewUseCase.java
@@ -1,0 +1,10 @@
+package com.run_us.server.v2.running.run.service.usecase;
+
+import com.run_us.server.v2.running.run.domain.RunningPreview;
+import com.run_us.server.v2.running.run.service.model.GetRunPreviewResponse;
+
+public interface RunPreviewUseCase {
+  void updateRunPreview(String userId, Integer runId, RunningPreview preview);
+
+  GetRunPreviewResponse getRunPreview(Integer runId);
+}

--- a/src/main/java/com/run_us/server/v2/running/run/service/usecase/RunPreviewUseCaseImpl.java
+++ b/src/main/java/com/run_us/server/v2/running/run/service/usecase/RunPreviewUseCaseImpl.java
@@ -1,0 +1,30 @@
+package com.run_us.server.v2.running.run.service.usecase;
+
+import com.run_us.server.domains.user.domain.User;
+import com.run_us.server.domains.user.service.UserService;
+import com.run_us.server.v2.running.run.domain.RunningPreview;
+import com.run_us.server.v2.running.run.service.RunCommandService;
+import com.run_us.server.v2.running.run.service.RunQueryService;
+import com.run_us.server.v2.running.run.service.model.GetRunPreviewResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RunPreviewUseCaseImpl implements RunPreviewUseCase {
+
+  private final RunCommandService runCommandService;
+  private final UserService userService;
+  private final RunQueryService runQueryService;
+
+  @Override
+  public void updateRunPreview(String userId, Integer runId, RunningPreview preview) {
+    User user = userService.getUserByPublicId(userId);
+    runCommandService.updateRunPreview(user.getId(), runId, preview);
+  }
+
+  @Override
+  public GetRunPreviewResponse getRunPreview(Integer runId) {
+    return runQueryService.getRunPreviewById(runId);
+  }
+}

--- a/src/main/java/com/run_us/server/v2/running/run/service/usecase/RunRegisterUseCase.java
+++ b/src/main/java/com/run_us/server/v2/running/run/service/usecase/RunRegisterUseCase.java
@@ -1,0 +1,12 @@
+package com.run_us.server.v2.running.run.service.usecase;
+
+import com.run_us.server.v2.running.run.service.model.ParticipantInfo;
+import java.util.List;
+
+public interface RunRegisterUseCase {
+  void registerRun(String userId, String runPublicId);
+
+  void cancelRun(String userId, String runPublicId);
+
+  List<ParticipantInfo> getRunParticipants(String runPublicId);
+}

--- a/src/main/java/com/run_us/server/v2/running/run/service/usecase/RunRegisterUseCaseImpl.java
+++ b/src/main/java/com/run_us/server/v2/running/run/service/usecase/RunRegisterUseCaseImpl.java
@@ -1,0 +1,40 @@
+package com.run_us.server.v2.running.run.service.usecase;
+
+import com.run_us.server.domains.user.domain.User;
+import com.run_us.server.domains.user.service.UserService;
+import com.run_us.server.v2.running.run.domain.Run;
+import com.run_us.server.v2.running.run.service.ParticipantService;
+import com.run_us.server.v2.running.run.service.RunQueryService;
+import com.run_us.server.v2.running.run.service.model.ParticipantInfo;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RunRegisterUseCaseImpl implements RunRegisterUseCase{
+
+  private final UserService userService;
+  private final RunQueryService runQueryService;
+  private final ParticipantService participantService;
+
+  @Override
+  public void registerRun(String userId, String runPublicId) {
+    User user = userService.getUserByPublicId(userId);
+    Run run = runQueryService.findByRunPublicId(runPublicId);
+    participantService.registerParticipant(user.getId(), run);
+  }
+
+  @Override
+  public void cancelRun(String userId, String runPublicId) {
+    User user = userService.getUserByPublicId(userId);
+    Run run = runQueryService.findByRunPublicId(runPublicId);
+    participantService.cancelParticipant(user.getId(), run);
+  }
+
+  @Override
+  public List<ParticipantInfo> getRunParticipants(String runPublicId) {
+    Run run = runQueryService.findByRunPublicId(runPublicId);
+    return participantService.getParticipants(run);
+  }
+}

--- a/src/test/java/com/run_us/server/v2/RunFixtures.java
+++ b/src/test/java/com/run_us/server/v2/RunFixtures.java
@@ -1,0 +1,28 @@
+package com.run_us.server.v2;
+
+import com.run_us.server.v2.running.run.domain.Run;
+import com.run_us.server.v2.running.run.domain.RunPace;
+import com.run_us.server.v2.running.run.domain.RunningPreview;
+
+import java.time.ZonedDateTime;
+
+public final class RunFixtures {
+
+  public static Run createRun() {
+    Run run = new Run(1);
+    run.modifySessionInfo(createRunningPreview());
+    return run;
+  }
+
+  private static RunningPreview createRunningPreview() {
+    return new RunningPreview(
+        "title",
+        "description",
+        "meetingPlace",
+        RunPace.PACE_UNDER_500,
+        "goal",
+        "visibility",
+        ZonedDateTime.now()
+    );
+  }
+}

--- a/src/test/java/com/run_us/server/v2/RunTest.java
+++ b/src/test/java/com/run_us/server/v2/RunTest.java
@@ -1,0 +1,55 @@
+package com.run_us.server.v2;
+
+import com.run_us.server.v2.running.run.domain.Run;
+import com.run_us.server.v2.running.run.domain.RunPace;
+import com.run_us.server.v2.running.run.domain.RunStatus;
+import com.run_us.server.v2.running.run.domain.RunningPreview;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.ZonedDateTime;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class RunTest {
+
+  @DisplayName("생성 테스트")
+  @Test
+  void test_create_run() {
+    Run run = RunFixtures.createRun();
+
+    assertNotNull(run);
+  }
+
+  @DisplayName("러닝 종료 상태 전환 테스트")
+  @Test
+  void test_change_run_status_to_end() {
+    Run run = RunFixtures.createRun();
+    run.changeStatus(RunStatus.FINISHED);
+    assertEquals(run.getStatus(), RunStatus.FINISHED);
+  }
+
+  @DisplayName("러닝 세션 정보 수정")
+  @Test
+  void test_modify_run_session_info() {
+    Run run = RunFixtures.createRun();
+    ZonedDateTime now = ZonedDateTime.now();
+    RunningPreview runningPreview = new RunningPreview(
+        "제목",
+        "내용",
+        "평화의문",
+        RunPace.PACE_500,
+        "목표",
+        "public",
+        now
+    );
+
+    run.modifySessionInfo(runningPreview);
+
+    RunningPreview preview = run.getPreview();
+    Assertions.assertThat(preview.getTitle()).isEqualTo("제목");
+    Assertions.assertThat(preview.getMeetingPoint()).isEqualTo("평화의문");
+  }
+
+}


### PR DESCRIPTION
### 연관된 이슈를 적어주세요 📌
v.0.2.0에서 도메인에 대한 큰 변화와 재정립이 이루어지면서 기존의 러닝을 재설계 했습니다.

### 작업한 내용을 설명해주세요 ✔️
- Running 도메인 재작성
- Passcode, Live 제외한 기능들 재작성
- Controller - Service - Repository 였던 구조에서 
  **Controller - UseCase- Service - Repository**로 작성했습니다.
- Service에 모든 메서드를 담다 보니 너무 커진 책임과 코드가 생겼습니다. 따라서 유즈케이스별로 분리하고 도메인의 서비스를 이용하게 
전환해보았습니다.
#33 에서 그렸던 구조로 결국 가게되었네요. **도메인의 서비스는 Query, Command로 나누어 조회와 수정을 분리**했습니다.

### 트러블 슈팅

### 리뷰어에게 하고 싶은 말을 적어주세요
- 며칠간 고민하다가 결국 지금의 코드로 작성을 하게되었어요. 어떻게하면 코드를 이해하기 쉽게짤까를 고민하다가. **영역별로 구분하고
인터페이스만 읽어도 어떤 기능을 담당하겠구나를 알 수 있게 하려다보니 저런 구조가 되었네요.**
- Record 도메인도 작성을 했는데 **구조에 대한 피드백등을 받고 고쳐서 올리기위해** Run도메인만 PR로 올렸습니다.

- Controller > UseCase > Service를 따라가시면 편합니다 ㅎ
### 확인하기

- [x] : 코드에 에러가 없는지 확인했나요?
- [x] : PR에 설명을 기재했나요?
- [x] : PR 태그를 붙였나요?
- [x] : 불필요한 로그나 `System.out`을 제거했나요?