### PR TITLE
[Feat/implement passcode generator for live runningSession] - 입장코드 발급 기능 개발

### DIFF
--- a/src/main/java/com/run_us/server/v2/RunningHttpResponseCode.java
+++ b/src/main/java/com/run_us/server/v2/RunningHttpResponseCode.java
@@ -12,7 +12,8 @@ public enum RunningHttpResponseCode implements CustomResponseCode {
   RUNNING_DELETED("RSH2006", "러닝 삭제 성공", "러닝 삭제 성공"),
   GROUP_RECORD_SAVED("RSH2007", "그룹런 기록 저장 성공", "그룹런 기록 저장 성공"),
   RUN_PREVIEW_FETCHED("RSH2008", "러닝 세션글 조회 성공", "러닝 세션글 조회 성공"),
-  RUN_PREVIEW_CREATED("RSH2009", "러닝 세션글 수정 성공", "러닝 세션글 수정 성공");
+  RUN_PREVIEW_CREATED("RSH2009", "러닝 세션글 수정 성공", "러닝 세션글 수정 성공"),
+  LIVE_ROOM_CREATED("RSH2011", "라이브 러닝방 생성 성공", "라이브 러닝방 생성 성공"),;
 
   private final String code;
   private final String clientMessage;

--- a/src/main/java/com/run_us/server/v2/running/common/PassCodeGenerator.java
+++ b/src/main/java/com/run_us/server/v2/running/common/PassCodeGenerator.java
@@ -1,0 +1,21 @@
+package com.run_us.server.v2.running.common;
+
+import java.security.SecureRandom;
+import java.util.Random;
+
+public final class PassCodeGenerator {
+
+  private static final String CHARSET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+  private static final int CHARSET_SIZE = 36;
+  private static final int CODE_LEN = 4;
+
+  public static String generatePassCode() {
+    StringBuilder sb = new StringBuilder();
+    // create random object every call to ensure randomness based on system-clock
+    Random random = new SecureRandom();
+    for(int i = 0; i < CODE_LEN; i++) {
+      sb.append(CHARSET.charAt(random.nextInt(CHARSET_SIZE)));
+    }
+    return sb.toString();
+  }
+}

--- a/src/main/java/com/run_us/server/v2/running/common/PassCodeRegistry.java
+++ b/src/main/java/com/run_us/server/v2/running/common/PassCodeRegistry.java
@@ -1,0 +1,7 @@
+package com.run_us.server.v2.running.common;
+
+public interface PassCodeRegistry {
+  String generateAndGetPassCode(String runId);
+  void unregisterPassCode(String passCode);
+  String getRunIdByPassCode(String passCode);
+}

--- a/src/main/java/com/run_us/server/v2/running/common/RedisPassCodeRegistry.java
+++ b/src/main/java/com/run_us/server/v2/running/common/RedisPassCodeRegistry.java
@@ -1,0 +1,43 @@
+package com.run_us.server.v2.running.common;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.TimeUnit;
+
+@Component
+@RequiredArgsConstructor
+public class RedisPassCodeRegistry implements PassCodeRegistry{
+
+  private final RedisTemplate<String, String> redisTemplate;
+  private static final int MAX_RETRIES = 10;
+
+  @Override
+  public String generateAndGetPassCode(String runId) {
+    String passCode;
+    int retries = 0;
+
+    // 최대 재시도 횟수를 넘어가면 예외를 발생시킨다.
+    // 초당 방 생성 요청 62개이상, 활성화된 입장코드가 68만개 이상일때
+    // 10번 재시도 실패확률이 1%이상으로 예상되며 이때 예외를 발생시킨다.
+    while (retries < MAX_RETRIES) {
+      passCode = PassCodeGenerator.generatePassCode();
+      if (Boolean.TRUE.equals(redisTemplate.opsForValue().setIfAbsent(passCode, runId, 3, TimeUnit.HOURS))) {
+        return passCode;
+      }
+      retries++;
+    }
+    throw new IllegalStateException("Failed to generate pass code");
+  }
+
+  @Override
+  public void unregisterPassCode(String passCode) {
+    redisTemplate.delete(passCode);
+  }
+
+  @Override
+  public String getRunIdByPassCode(String passCode) {
+    return redisTemplate.opsForValue().get(passCode);
+  }
+}

--- a/src/main/java/com/run_us/server/v2/running/run/controller/RunController.java
+++ b/src/main/java/com/run_us/server/v2/running/run/controller/RunController.java
@@ -3,8 +3,9 @@ package com.run_us.server.v2.running.run.controller;
 import com.run_us.server.global.common.SuccessResponse;
 import com.run_us.server.v2.RunningHttpResponseCode;
 import com.run_us.server.v2.running.run.controller.model.request.SessionRunCreateRequest;
+import com.run_us.server.v2.running.run.service.model.CustomRunCreateResponse;
 import com.run_us.server.v2.running.run.service.model.ParticipantInfo;
-import com.run_us.server.v2.running.run.service.model.RunCreateResponse;
+import com.run_us.server.v2.running.run.service.model.SessionRunCreateResponse;
 import com.run_us.server.v2.running.run.service.usecase.RunCreateUseCase;
 import com.run_us.server.v2.running.run.service.usecase.RunRegisterUseCase;
 import java.util.List;
@@ -23,7 +24,7 @@ public class RunController {
   private final RunRegisterUseCase runRegisterUseCase;
 
   @PostMapping(params = "mode=custom")
-  public SuccessResponse<RunCreateResponse> createCustomRun(
+  public SuccessResponse<CustomRunCreateResponse> createCustomRun(
       @RequestAttribute("publicUserId") String userId) {
     log.info("action=create_custom_running user_id={}", userId);
     return SuccessResponse.of(
@@ -31,7 +32,7 @@ public class RunController {
   }
 
   @PostMapping(params = "mode=normal")
-  public SuccessResponse<RunCreateResponse> createNormalRun(
+  public SuccessResponse<SessionRunCreateResponse> createNormalRun(
       @RequestBody SessionRunCreateRequest runningCreateRequest,
       @RequestAttribute("publicUserId") String userId) {
     log.info("action=create_session_running user_id={}", userId);

--- a/src/main/java/com/run_us/server/v2/running/run/domain/Run.java
+++ b/src/main/java/com/run_us/server/v2/running/run/domain/Run.java
@@ -24,8 +24,6 @@ public class Run extends CreationTimeAudit {
 
   private String publicId;
 
-  private String passcode;
-
   @Enumerated(EnumType.STRING)
   private RunStatus status;
 

--- a/src/main/java/com/run_us/server/v2/running/run/service/model/CustomRunCreateResponse.java
+++ b/src/main/java/com/run_us/server/v2/running/run/service/model/CustomRunCreateResponse.java
@@ -4,16 +4,16 @@ import com.run_us.server.v2.running.run.domain.Run;
 import lombok.Getter;
 
 @Getter
-public class RunCreateResponse {
+public class CustomRunCreateResponse {
   private final String runningId;
   private final String passcode;
 
-  private RunCreateResponse(String runningId, String passcode) {
+  private CustomRunCreateResponse(String runningId, String passcode) {
     this.runningId = runningId;
     this.passcode = passcode;
   }
 
-  public static RunCreateResponse from(Run run) {
-    return new RunCreateResponse(run.getPublicId(), run.getPasscode());
+  public static CustomRunCreateResponse from(Run run, String passcode) {
+    return new CustomRunCreateResponse(run.getPublicId(), passcode);
   }
 }

--- a/src/main/java/com/run_us/server/v2/running/run/service/model/SessionRunCreateResponse.java
+++ b/src/main/java/com/run_us/server/v2/running/run/service/model/SessionRunCreateResponse.java
@@ -1,0 +1,20 @@
+package com.run_us.server.v2.running.run.service.model;
+
+import com.run_us.server.v2.running.run.domain.Run;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SessionRunCreateResponse {
+  private String runningId;
+
+  public SessionRunCreateResponse(String runningId) {
+    this.runningId = runningId;
+  }
+
+  public static SessionRunCreateResponse from (Run run) {
+    return new SessionRunCreateResponse(run.getPublicId());
+  }
+}

--- a/src/main/java/com/run_us/server/v2/running/run/service/usecase/RunCreateUseCase.java
+++ b/src/main/java/com/run_us/server/v2/running/run/service/usecase/RunCreateUseCase.java
@@ -1,10 +1,11 @@
 package com.run_us.server.v2.running.run.service.usecase;
 
 import com.run_us.server.v2.running.run.domain.RunningPreview;
-import com.run_us.server.v2.running.run.service.model.RunCreateResponse;
+import com.run_us.server.v2.running.run.service.model.CustomRunCreateResponse;
+import com.run_us.server.v2.running.run.service.model.SessionRunCreateResponse;
 
 public interface RunCreateUseCase {
-  RunCreateResponse saveNewCustomRun(String userId);
+  CustomRunCreateResponse saveNewCustomRun(String userId);
 
-  RunCreateResponse saveNewSessionRun(String userId, RunningPreview runningPreview);
+  SessionRunCreateResponse saveNewSessionRun(String userId, RunningPreview runningPreview);
 }

--- a/src/main/java/com/run_us/server/v2/running/run/service/usecase/RunCreateUseCaseImpl.java
+++ b/src/main/java/com/run_us/server/v2/running/run/service/usecase/RunCreateUseCaseImpl.java
@@ -2,9 +2,12 @@ package com.run_us.server.v2.running.run.service.usecase;
 
 import com.run_us.server.domains.user.domain.User;
 import com.run_us.server.domains.user.service.UserService;
+import com.run_us.server.v2.running.common.PassCodeRegistry;
+import com.run_us.server.v2.running.run.domain.Run;
 import com.run_us.server.v2.running.run.domain.RunningPreview;
 import com.run_us.server.v2.running.run.service.RunCommandService;
-import com.run_us.server.v2.running.run.service.model.RunCreateResponse;
+import com.run_us.server.v2.running.run.service.model.CustomRunCreateResponse;
+import com.run_us.server.v2.running.run.service.model.SessionRunCreateResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -14,15 +17,19 @@ public class RunCreateUseCaseImpl implements RunCreateUseCase {
 
   private final RunCommandService runCommandService;
   private final UserService userService;
+  private final PassCodeRegistry passCodeRegistry;
 
-  public RunCreateResponse saveNewCustomRun(String userId) {
+  // Custom Run은 생성하면서 바로 Passcode를 생성하여 반환한다.
+  public CustomRunCreateResponse saveNewCustomRun(String userId) {
     User user = userService.getUserByPublicId(userId);
-    return RunCreateResponse.from(runCommandService.saveNewRun(user, null));
+    Run run = runCommandService.saveNewRun(user, null);
+    String passcode = passCodeRegistry.generateAndGetPassCode(run.getPublicId());
+    return CustomRunCreateResponse.from(run, passcode);
   }
 
   @Override
-  public RunCreateResponse saveNewSessionRun(String userId, RunningPreview runningPreview) {
+  public SessionRunCreateResponse saveNewSessionRun(String userId, RunningPreview runningPreview) {
     User user = userService.getUserByPublicId(userId);
-    return RunCreateResponse.from(runCommandService.saveNewRun(user, runningPreview));
+    return SessionRunCreateResponse.from(runCommandService.saveNewRun(user, runningPreview));
   }
 }


### PR DESCRIPTION
### 연관된 이슈를 적어주세요 📌

### 작업한 내용을 설명해주세요 ✔️

- 입장코드 생성 컴포넌트 작성
- 레디스를 통한 단일 키 보장 설계
- 유일 키 생성까지 최대 10번 시도, 10번 초과 시 에러 반환

### 트러블 슈팅

### 리뷰어에게 하고 싶은 말을 적어주세요
- 서버 내에서 입장코드 - 런 쌍은 유일해야합니다. (특정 시점)
- live 러닝이 시작되면 입장코드는 다시 반환되며 다른 방에서 획득할 수 있습니다.
- [0-9A-Z]로 생성한 4자리 코드는 36^4 개입니다. 이때 방 생성 요청이 분당 10건, 입장코드가 유지되는 평균시간(러닝이 시작하거나 취소될때까지)을 10분으로 가정하고 입장코드의 충돌확률을 따져보니 0.001% 미만의 확률로 충돌하더군요. (채찍티비에게 시켰습니다.)
트래픽을 높이고 다시 계산해봐도 10번 재시도를 실패할 확률이 매우 낮아 지금의 로직으로 정했습니다. 
### 확인하기

- [ ] : 코드에 에러가 없는지 확인했나요?
- [ ] : PR에 설명을 기재했나요?
- [ ] : PR 태그를 붙였나요?
- [ ] : 불필요한 로그나 `System.out`을 제거했나요?