### PR TITLE
[Feat/crew join request process] - 크루 가입요청 생성 및 취소

### DIFF
--- a/src/main/java/com/run_us/server/domains/crew/controller/CrewController.java
+++ b/src/main/java/com/run_us/server/domains/crew/controller/CrewController.java
@@ -1,0 +1,38 @@
+package com.run_us.server.domains.crew.controller;
+
+import com.run_us.server.domains.crew.controller.model.enums.CrewHttpResponseCode;
+import com.run_us.server.domains.crew.controller.model.request.CreateJoinRequest;
+import com.run_us.server.domains.crew.controller.model.response.CreateJoinRequestResponse;
+import com.run_us.server.domains.crew.controller.model.response.CrewJoinRequestInternalResponse;
+import com.run_us.server.domains.crew.service.usecase.CrewJoinUseCase;
+import com.run_us.server.global.common.SuccessResponse;
+
+import com.run_us.server.global.security.annotation.CurrentUser;
+import com.run_us.server.global.security.principal.UserPrincipal;
+import jakarta.validation.Valid;
+import lombok.extern.slf4j.Slf4j;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequestMapping("/crews")
+@RequiredArgsConstructor
+public class CrewController {
+    private final CrewJoinUseCase crewJoinUseCase;
+
+    @PostMapping("/{crewPublicId}/join-requests")
+    public ResponseEntity<SuccessResponse<CreateJoinRequestResponse>> requestJoin(
+            @PathVariable String crewPublicId,
+            @CurrentUser UserPrincipal userPrincipal,
+            @Valid @RequestBody CreateJoinRequest request
+    ) {
+        log.info("action=request_join crewPublicId={} userPublicId={}", crewPublicId, userPrincipal.getPublicId());
+        CrewJoinRequestInternalResponse response = crewJoinUseCase.createJoinRequest(crewPublicId, userPrincipal.getInternalId(), request);
+        return ResponseEntity.ok(
+                SuccessResponse.of(
+                        CrewHttpResponseCode.JOIN_REQUEST_CREATED,
+                        response.toPublicCreateResponse(userPrincipal.getPublicId())));
+    }
+}

--- a/src/main/java/com/run_us/server/domains/crew/controller/CrewController.java
+++ b/src/main/java/com/run_us/server/domains/crew/controller/CrewController.java
@@ -2,6 +2,7 @@ package com.run_us.server.domains.crew.controller;
 
 import com.run_us.server.domains.crew.controller.model.enums.CrewHttpResponseCode;
 import com.run_us.server.domains.crew.controller.model.request.CreateJoinRequest;
+import com.run_us.server.domains.crew.controller.model.response.CancelJoinRequestResponse;
 import com.run_us.server.domains.crew.controller.model.response.CreateJoinRequestResponse;
 import com.run_us.server.domains.crew.controller.model.response.CrewJoinRequestInternalResponse;
 import com.run_us.server.domains.crew.service.usecase.CrewJoinUseCase;
@@ -34,5 +35,20 @@ public class CrewController {
                 SuccessResponse.of(
                         CrewHttpResponseCode.JOIN_REQUEST_CREATED,
                         response.toPublicCreateResponse(userPrincipal.getPublicId())));
+    }
+
+    @DeleteMapping("/{crewPublicId}/join-requests")
+    public ResponseEntity<SuccessResponse<CancelJoinRequestResponse>> cancelJoinRequest(
+            @PathVariable String crewPublicId,
+            @CurrentUser UserPrincipal userPrincipal
+    ) {
+        log.info("action=cancel_join_request crewPublicId={} userPublicId={}", crewPublicId, userPrincipal.getPublicId());
+        CrewJoinRequestInternalResponse response = crewJoinUseCase.cancelJoinRequest(crewPublicId, userPrincipal.getInternalId());
+        return ResponseEntity.ok(
+                SuccessResponse.of(
+                        CrewHttpResponseCode.JOIN_REQUEST_CANCELLED,
+                        response.toPublicCancelResponse()
+                )
+        );
     }
 }

--- a/src/main/java/com/run_us/server/domains/crew/controller/model/enums/CrewErrorCode.java
+++ b/src/main/java/com/run_us/server/domains/crew/controller/model/enums/CrewErrorCode.java
@@ -5,16 +5,16 @@ import org.springframework.http.HttpStatus;
 
 public enum CrewErrorCode implements CustomResponseCode {
     // 404
-    CREW_NOT_FOUND("CEH4001", "Crew not found", "Crew not found", HttpStatus.NOT_FOUND),
-    JOIN_REQUEST_NOT_FOUND("CEH4002", "Join request not found", "Join request not found", HttpStatus.NOT_FOUND),
+    CREW_NOT_FOUND("CEH4041", "Crew not found", "Crew not found", HttpStatus.NOT_FOUND),
+    JOIN_REQUEST_NOT_FOUND("CEH4042", "Join request not found", "Join request not found", HttpStatus.NOT_FOUND),
 
     // 400
-    INVALID_JOIN_REQUEST("CEH4003", "Invalid join request", "Invalid join request", HttpStatus.BAD_REQUEST),
-    ALREADY_CREW_MEMBER("CEH4004", "User is already a crew member", "User is already a crew member", HttpStatus.BAD_REQUEST),
-    DUPLICATE_JOIN_REQUEST("CEH4005", "Duplicate join request", "Duplicate join request", HttpStatus.BAD_REQUEST),
+    INVALID_JOIN_REQUEST("CEH4001", "Invalid join request", "Invalid join request", HttpStatus.BAD_REQUEST),
+    ALREADY_CREW_MEMBER("CEH4002", "User is already a crew member", "User is already a crew member", HttpStatus.BAD_REQUEST),
+    DUPLICATE_JOIN_REQUEST("CEH4003", "Duplicate join request", "Duplicate join request", HttpStatus.BAD_REQUEST),
 
     // 403
-    NOT_CREW_OWNER("CEH4007", "User is not crew owner", "User is not crew owner", HttpStatus.FORBIDDEN)
+    NOT_CREW_OWNER("CEH4031", "User is not crew owner", "User is not crew owner", HttpStatus.FORBIDDEN)
     ;
 
     private final String code;

--- a/src/main/java/com/run_us/server/domains/crew/controller/model/enums/CrewErrorCode.java
+++ b/src/main/java/com/run_us/server/domains/crew/controller/model/enums/CrewErrorCode.java
@@ -1,0 +1,52 @@
+package com.run_us.server.domains.crew.controller.model.enums;
+
+import com.run_us.server.global.exception.code.CustomResponseCode;
+import org.springframework.http.HttpStatus;
+
+public enum CrewErrorCode implements CustomResponseCode {
+    // 404
+    CREW_NOT_FOUND("CEH4001", "Crew not found", "Crew not found", HttpStatus.NOT_FOUND),
+    JOIN_REQUEST_NOT_FOUND("CEH4002", "Join request not found", "Join request not found", HttpStatus.NOT_FOUND),
+
+    // 400
+    INVALID_JOIN_REQUEST("CEH4003", "Invalid join request", "Invalid join request", HttpStatus.BAD_REQUEST),
+    ALREADY_CREW_MEMBER("CEH4004", "User is already a crew member", "User is already a crew member", HttpStatus.BAD_REQUEST),
+    DUPLICATE_JOIN_REQUEST("CEH4005", "Duplicate join request", "Duplicate join request", HttpStatus.BAD_REQUEST),
+
+    // 403
+    NOT_CREW_OWNER("CEH4007", "User is not crew owner", "User is not crew owner", HttpStatus.FORBIDDEN)
+    ;
+
+    private final String code;
+    private final String clientMessage;
+    private final String logMessage;
+    private final HttpStatus httpStatusCode;
+
+    CrewErrorCode(
+            String code, String clientMessage, String logMessage, HttpStatus httpStatusCode) {
+        this.code = code;
+        this.clientMessage = clientMessage;
+        this.logMessage = logMessage;
+        this.httpStatusCode = httpStatusCode;
+    }
+
+    @Override
+    public String getCode() {
+        return this.code;
+    }
+
+    @Override
+    public String getClientMessage() {
+        return this.clientMessage;
+    }
+
+    @Override
+    public String getLogMessage() {
+        return this.logMessage;
+    }
+
+    @Override
+    public HttpStatus getHttpStatusCode() {
+        return this.httpStatusCode;
+    }
+}

--- a/src/main/java/com/run_us/server/domains/crew/controller/model/enums/CrewErrorCode.java
+++ b/src/main/java/com/run_us/server/domains/crew/controller/model/enums/CrewErrorCode.java
@@ -14,7 +14,8 @@ public enum CrewErrorCode implements CustomResponseCode {
     DUPLICATE_JOIN_REQUEST("CEH4003", "Duplicate join request", "Duplicate join request", HttpStatus.BAD_REQUEST),
 
     // 403
-    NOT_CREW_OWNER("CEH4031", "User is not crew owner", "User is not crew owner", HttpStatus.FORBIDDEN)
+    NOT_CREW_OWNER("CEH4031", "User is not crew owner", "User is not crew owner", HttpStatus.FORBIDDEN),
+    RECENTLY_REJECTED_REQUEST("CEH4032","Recently rejected request","Recently rejected request",HttpStatus.FORBIDDEN)
     ;
 
     private final String code;

--- a/src/main/java/com/run_us/server/domains/crew/controller/model/enums/CrewException.java
+++ b/src/main/java/com/run_us/server/domains/crew/controller/model/enums/CrewException.java
@@ -1,0 +1,19 @@
+package com.run_us.server.domains.crew.controller.model.enums;
+
+import com.run_us.server.global.exception.BusinessException;
+import com.run_us.server.global.exception.code.CustomResponseCode;
+
+public class CrewException extends BusinessException {
+
+    public CrewException(CustomResponseCode errorCode) {
+        super(errorCode);
+    }
+
+    public CrewException(CustomResponseCode errorCode, String logMessage) {
+        super(errorCode, logMessage);
+    }
+
+    public static CrewException of(CustomResponseCode errorCode) {
+        return new CrewException(errorCode);
+    }
+}

--- a/src/main/java/com/run_us/server/domains/crew/controller/model/enums/CrewHttpResponseCode.java
+++ b/src/main/java/com/run_us/server/domains/crew/controller/model/enums/CrewHttpResponseCode.java
@@ -14,6 +14,7 @@ public enum CrewHttpResponseCode implements CustomResponseCode {
     CREW_SEARCH_SUCCESS("CSH2006", HttpStatus.OK, "크루 검색 성공", "크루 검색 성공"),
     CREW_CLOSE_SUCCESS("CSH2007", HttpStatus.OK, "크루 폐쇄 성공", "크루 폐쇄 성공"),
 
+    JOIN_REQUEST_CREATED("CSH2021", HttpStatus.CREATED, "크루 가입 요청 성공", "크루 가입 요청 성공"),
 
     ;
 

--- a/src/main/java/com/run_us/server/domains/crew/controller/model/enums/CrewHttpResponseCode.java
+++ b/src/main/java/com/run_us/server/domains/crew/controller/model/enums/CrewHttpResponseCode.java
@@ -15,6 +15,7 @@ public enum CrewHttpResponseCode implements CustomResponseCode {
     CREW_CLOSE_SUCCESS("CSH2007", HttpStatus.OK, "크루 폐쇄 성공", "크루 폐쇄 성공"),
 
     JOIN_REQUEST_CREATED("CSH2021", HttpStatus.CREATED, "크루 가입 요청 성공", "크루 가입 요청 성공"),
+    JOIN_REQUEST_CANCELLED("CSH2008", HttpStatus.OK, "크루 가입 요청 취소 성공", "크루 가입 요청 취소 성공"),
 
     ;
 

--- a/src/main/java/com/run_us/server/domains/crew/controller/model/enums/CrewHttpResponseCode.java
+++ b/src/main/java/com/run_us/server/domains/crew/controller/model/enums/CrewHttpResponseCode.java
@@ -1,4 +1,4 @@
-package com.run_us.server.domains.crew.controller.model.response;
+package com.run_us.server.domains.crew.controller.model.enums;
 
 import com.run_us.server.global.exception.code.CustomResponseCode;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/run_us/server/domains/crew/controller/model/request/CreateJoinRequest.java
+++ b/src/main/java/com/run_us/server/domains/crew/controller/model/request/CreateJoinRequest.java
@@ -1,0 +1,21 @@
+package com.run_us.server.domains.crew.controller.model.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.Length;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CreateJoinRequest {
+    @NotNull
+    @Length(max = 100)
+    private String answer;
+
+    @Builder
+    public CreateJoinRequest(String answer) {
+        this.answer = answer;
+    }
+}

--- a/src/main/java/com/run_us/server/domains/crew/controller/model/response/CancelJoinRequestResponse.java
+++ b/src/main/java/com/run_us/server/domains/crew/controller/model/response/CancelJoinRequestResponse.java
@@ -1,0 +1,10 @@
+package com.run_us.server.domains.crew.controller.model.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CancelJoinRequestResponse {
+    private final Integer requestId;
+}

--- a/src/main/java/com/run_us/server/domains/crew/controller/model/response/CreateJoinRequestResponse.java
+++ b/src/main/java/com/run_us/server/domains/crew/controller/model/response/CreateJoinRequestResponse.java
@@ -1,0 +1,17 @@
+package com.run_us.server.domains.crew.controller.model.response;
+
+import com.run_us.server.domains.crew.domain.enums.CrewJoinRequestStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.ZonedDateTime;
+
+@Getter
+@Builder
+public class CreateJoinRequestResponse {
+    private final Integer requestId;
+    private final String crewPublicId;
+    private final String userPublicId;
+    private final CrewJoinRequestStatus status;
+    private final ZonedDateTime requestedAt;
+}

--- a/src/main/java/com/run_us/server/domains/crew/controller/model/response/CrewJoinRequestInternalResponse.java
+++ b/src/main/java/com/run_us/server/domains/crew/controller/model/response/CrewJoinRequestInternalResponse.java
@@ -1,0 +1,25 @@
+package com.run_us.server.domains.crew.controller.model.response;
+
+import com.run_us.server.domains.crew.domain.enums.CrewJoinRequestStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.ZonedDateTime;
+
+@Getter
+@Builder
+public class CrewJoinRequestInternalResponse {
+    private final String crewPublicId;
+    private final Integer userInternalId;
+    private final CrewJoinRequestStatus status;
+    private final ZonedDateTime requestedAt;
+
+    public CreateJoinRequestResponse toPublicCreateResponse(String userPublicId) {
+        return CreateJoinRequestResponse.builder()
+                .crewPublicId(this.crewPublicId)
+                .userPublicId(userPublicId)
+                .status(this.status)
+                .requestedAt(this.requestedAt)
+                .build();
+    }
+}

--- a/src/main/java/com/run_us/server/domains/crew/controller/model/response/CrewJoinRequestInternalResponse.java
+++ b/src/main/java/com/run_us/server/domains/crew/controller/model/response/CrewJoinRequestInternalResponse.java
@@ -9,6 +9,7 @@ import java.time.ZonedDateTime;
 @Getter
 @Builder
 public class CrewJoinRequestInternalResponse {
+    private final Integer id;
     private final String crewPublicId;
     private final Integer userInternalId;
     private final CrewJoinRequestStatus status;
@@ -16,6 +17,7 @@ public class CrewJoinRequestInternalResponse {
 
     public CreateJoinRequestResponse toPublicCreateResponse(String userPublicId) {
         return CreateJoinRequestResponse.builder()
+                .requestId(this.id)
                 .crewPublicId(this.crewPublicId)
                 .userPublicId(userPublicId)
                 .status(this.status)

--- a/src/main/java/com/run_us/server/domains/crew/controller/model/response/CrewJoinRequestInternalResponse.java
+++ b/src/main/java/com/run_us/server/domains/crew/controller/model/response/CrewJoinRequestInternalResponse.java
@@ -24,4 +24,10 @@ public class CrewJoinRequestInternalResponse {
                 .requestedAt(this.requestedAt)
                 .build();
     }
+
+    public CancelJoinRequestResponse toPublicCancelResponse() {
+        return CancelJoinRequestResponse.builder()
+                .requestId(this.id)
+                .build();
+    }
 }

--- a/src/main/java/com/run_us/server/domains/crew/domain/Crew.java
+++ b/src/main/java/com/run_us/server/domains/crew/domain/Crew.java
@@ -1,5 +1,6 @@
 package com.run_us.server.domains.crew.domain;
 
+import com.run_us.server.domains.crew.domain.enums.CrewJoinRequestStatus;
 import com.run_us.server.domains.crew.domain.enums.CrewJoinType;
 import com.run_us.server.domains.crew.domain.enums.CrewStatus;
 import com.run_us.server.domains.user.domain.User;
@@ -11,6 +12,7 @@ import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.SQLRestriction;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 @ToString
@@ -57,6 +59,39 @@ public class Crew extends DateAudit {
     @Column(name = "deleted_at", nullable = false)
     private LocalDateTime deletedAt;
 
+    public boolean isMember(Integer userId) {
+        return crewMemberships.stream()
+                .anyMatch(membership -> membership.getUserId().equals(userId));
+    }
+
+    public boolean isActive() {
+        return this.status == CrewStatus.ACTIVE;
+    }
+
+    public boolean hasWaitingRequest(Integer userId) {
+        return joinRequests.stream()
+                .anyMatch(request ->
+                        request.getUserId().equals(userId) &&
+                                request.getStatus() == CrewJoinRequestStatus.WAITING
+                );
+    }
+
+    public void addJoinRequest(CrewJoinRequest joinRequest) {
+        if (this.joinRequests == null) {
+            this.joinRequests = new ArrayList<>();
+        }
+        this.joinRequests.add(joinRequest);
+    }
+
+    public void addMember(Integer userId) {
+        if (this.crewMemberships == null) {
+            this.crewMemberships = new ArrayList<>();
+        }
+        this.crewMemberships.add(CrewMembership.builder()
+            .userId(userId)
+            .build()
+        );
+    }
 
     @Override
     public void prePersist() {

--- a/src/main/java/com/run_us/server/domains/crew/domain/Crew.java
+++ b/src/main/java/com/run_us/server/domains/crew/domain/Crew.java
@@ -80,6 +80,10 @@ public class Crew extends DateAudit {
         this.joinRequests.add(joinRequest);
     }
 
+    public void removeJoinRequest(CrewJoinRequest joinRequest) {
+        this.joinRequests.remove(joinRequest);
+    }
+
     public void addMember(Integer userId) {
         this.crewMemberships.add(CrewMembership.builder()
             .userId(userId)

--- a/src/main/java/com/run_us/server/domains/crew/domain/Crew.java
+++ b/src/main/java/com/run_us/server/domains/crew/domain/Crew.java
@@ -50,11 +50,11 @@ public class Crew extends DateAudit {
 
     @ElementCollection
     @CollectionTable(name = "crew_join_requests", joinColumns = @JoinColumn(name="crew_id"))
-    private List<CrewJoinRequest> joinRequests;
+    private List<CrewJoinRequest> joinRequests = new ArrayList<>();
 
     @ElementCollection
     @CollectionTable(name = "crew_memberships", joinColumns = @JoinColumn(name="crew_id"))
-    private List<CrewMembership> crewMemberships;
+    private List<CrewMembership> crewMemberships = new ArrayList<>();
 
     @Column(name = "deleted_at", nullable = false)
     private LocalDateTime deletedAt;
@@ -77,16 +77,10 @@ public class Crew extends DateAudit {
     }
 
     public void addJoinRequest(CrewJoinRequest joinRequest) {
-        if (this.joinRequests == null) {
-            this.joinRequests = new ArrayList<>();
-        }
         this.joinRequests.add(joinRequest);
     }
 
     public void addMember(Integer userId) {
-        if (this.crewMemberships == null) {
-            this.crewMemberships = new ArrayList<>();
-        }
         this.crewMemberships.add(CrewMembership.builder()
             .userId(userId)
             .build()

--- a/src/main/java/com/run_us/server/domains/crew/domain/CrewJoinRequest.java
+++ b/src/main/java/com/run_us/server/domains/crew/domain/CrewJoinRequest.java
@@ -74,6 +74,17 @@ public class CrewJoinRequest {
         this.processedBy = processedBy;
     }
 
+    public void reject(User processedBy) {
+        this.status = CrewJoinRequestStatus.REJECTED;
+        this.processedAt = ZonedDateTime.now();
+        this.processedBy = processedBy;
+    }
+
+    public void cancel() {
+        this.status = CrewJoinRequestStatus.CANCELED;
+        this.processedAt = ZonedDateTime.now();
+    }
+
     @Override
     public boolean equals(Object obj) {
         if (this == obj) {

--- a/src/main/java/com/run_us/server/domains/crew/domain/CrewJoinRequest.java
+++ b/src/main/java/com/run_us/server/domains/crew/domain/CrewJoinRequest.java
@@ -5,6 +5,7 @@ import com.run_us.server.domains.user.domain.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.Builder;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import org.hibernate.annotations.SQLRestriction;
@@ -27,6 +28,9 @@ public class CrewJoinRequest {
     @Enumerated(EnumType.STRING)
     private CrewJoinRequestStatus status;
 
+    @Column(name="answer", length = 100)
+    private String answer;
+
     @Column(name = "requested_at", nullable = false)
     private ZonedDateTime requestedAt;
 
@@ -36,6 +40,29 @@ public class CrewJoinRequest {
     @ManyToOne
     @JoinColumn(name = "processed_by")
     private User processedBy;
+
+    @Builder
+    public CrewJoinRequest(
+            Integer userId,
+            CrewJoinRequestStatus status,
+            String answer,
+            ZonedDateTime requestedAt,
+            ZonedDateTime processedAt,
+            User processedBy
+    ){
+        this.userId = userId;
+        this.status = status;
+        this.answer = answer;
+        this.requestedAt = requestedAt;
+        this.processedAt = processedAt;
+        this.processedBy = processedBy;
+    }
+
+    public void approve(User processedBy) {
+        this.status = CrewJoinRequestStatus.APPROVED;
+        this.processedAt = ZonedDateTime.now();
+        this.processedBy = processedBy;
+    }
 
     @Override
     public boolean equals(Object obj) {

--- a/src/main/java/com/run_us/server/domains/crew/domain/CrewJoinRequest.java
+++ b/src/main/java/com/run_us/server/domains/crew/domain/CrewJoinRequest.java
@@ -58,6 +58,13 @@ public class CrewJoinRequest {
         this.processedBy = processedBy;
     }
 
+    public static CrewJoinRequest from(Integer userId, String answer) {
+        return CrewJoinRequest.builder()
+                .userId(userId)
+                .answer(answer)
+                .build();
+    }
+
     public void approve(User processedBy) {
         this.status = CrewJoinRequestStatus.APPROVED;
         this.processedAt = ZonedDateTime.now();

--- a/src/main/java/com/run_us/server/domains/crew/domain/CrewJoinRequest.java
+++ b/src/main/java/com/run_us/server/domains/crew/domain/CrewJoinRequest.java
@@ -20,6 +20,9 @@ import java.util.Objects;
 @SQLRestriction("deleted_at is null")
 @Embeddable
 public class CrewJoinRequest {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
 
     @Column(nullable = false)
     private Integer userId;

--- a/src/main/java/com/run_us/server/domains/crew/domain/enums/CrewJoinRequestStatus.java
+++ b/src/main/java/com/run_us/server/domains/crew/domain/enums/CrewJoinRequestStatus.java
@@ -4,5 +4,6 @@ public enum CrewJoinRequestStatus {
     WAITING,
     APPROVED,
     REJECTED,
+    CANCELED
     ;
 }

--- a/src/main/java/com/run_us/server/domains/crew/repository/CrewRepository.java
+++ b/src/main/java/com/run_us/server/domains/crew/repository/CrewRepository.java
@@ -1,0 +1,10 @@
+package com.run_us.server.domains.crew.repository;
+
+import com.run_us.server.domains.crew.domain.Crew;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface CrewRepository extends JpaRepository<Crew, Integer> {
+    Optional<Crew> findByPublicId(String publicId);
+}

--- a/src/main/java/com/run_us/server/domains/crew/repository/CrewRepository.java
+++ b/src/main/java/com/run_us/server/domains/crew/repository/CrewRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 public interface CrewRepository extends JpaRepository<Crew, Integer> {
@@ -19,5 +20,24 @@ public interface CrewRepository extends JpaRepository<Crew, Integer> {
     Optional<CrewJoinRequest> findWaitingJoinRequest(
             @Param("crewId") String publicId,
             @Param("userId") Integer userInternalId
+    );
+
+    @Query("SELECT EXISTS (SELECT 1 FROM Crew c JOIN c.crewMemberships m " +
+            "WHERE c.id = :crewId AND m.userId = :userId)")
+    boolean existsMembershipByCrewIdAndUserId(Integer crewId, Integer userId);
+
+    @Query("SELECT EXISTS (SELECT 1 FROM Crew c JOIN c.joinRequests r " +
+            "WHERE c.id = :crewId AND r.userId = :userId " +
+            "AND r.status = 'WAITING')")
+    boolean existsWaitingRequestByCrewIdAndUserId(Integer crewId, Integer userId);
+
+    @Query("SELECT EXISTS (SELECT 1 FROM Crew c JOIN c.joinRequests r " +
+            "WHERE c.id = :crewId AND r.userId = :userId " +
+            "AND r.status = 'REJECTED' " +
+            "AND r.processedAt > :recentDate)")
+    boolean existsRecentRejectedRequestByCrewIdAndUserId(
+            Integer crewId,
+            Integer userId,
+            LocalDateTime recentDate
     );
 }

--- a/src/main/java/com/run_us/server/domains/crew/repository/CrewRepository.java
+++ b/src/main/java/com/run_us/server/domains/crew/repository/CrewRepository.java
@@ -1,10 +1,23 @@
 package com.run_us.server.domains.crew.repository;
 
 import com.run_us.server.domains.crew.domain.Crew;
+import com.run_us.server.domains.crew.domain.CrewJoinRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface CrewRepository extends JpaRepository<Crew, Integer> {
     Optional<Crew> findByPublicId(String publicId);
+
+    @Query("SELECT jr FROM Crew c " +
+            "JOIN c.joinRequests jr " +
+            "WHERE c.publicId = :publicId " +
+            "AND jr.userId = :userInternalId " +
+            "AND jr.status = 'WAITING'")
+    Optional<CrewJoinRequest> findWaitingJoinRequest(
+            @Param("crewId") String publicId,
+            @Param("userId") Integer userInternalId
+    );
 }

--- a/src/main/java/com/run_us/server/domains/crew/service/CrewService.java
+++ b/src/main/java/com/run_us/server/domains/crew/service/CrewService.java
@@ -27,10 +27,7 @@ public class CrewService {
     public CrewJoinRequest createJoinRequest(Crew crew, Integer userInternalId, String answer) {
         log.debug("action=create_join_request crewPublicId={} userInternalId={}", crew.getPublicId(), userInternalId);
 
-        CrewJoinRequest joinRequest = CrewJoinRequest.builder()
-                                                        .userId(userInternalId)
-                                                        .answer(answer)
-                                                        .build();
+        CrewJoinRequest joinRequest = CrewJoinRequest.from(userInternalId, answer);
 
         if (crew.getJoinType() == CrewJoinType.OPEN) {
             log.debug("action=auto_approve_join_request crewPublicId={} userInternalId={}", crew.getPublicId(), userInternalId);

--- a/src/main/java/com/run_us/server/domains/crew/service/CrewService.java
+++ b/src/main/java/com/run_us/server/domains/crew/service/CrewService.java
@@ -52,7 +52,7 @@ public class CrewService {
         CrewJoinRequest joinRequest = crewRepository.findWaitingJoinRequest(crew.getPublicId(), userInternalId)
                 .orElseThrow(() -> new CrewException(CrewErrorCode.JOIN_REQUEST_NOT_FOUND));
 
-        crew.removeJoinRequest(joinRequest);
+        crew.cancelJoinRequest(joinRequest);
         crewRepository.save(crew);
 
         log.debug("action=cancel_join_request_complete crewPublicId={} userInternalId={}", crew.getPublicId(), userInternalId);

--- a/src/main/java/com/run_us/server/domains/crew/service/CrewService.java
+++ b/src/main/java/com/run_us/server/domains/crew/service/CrewService.java
@@ -1,0 +1,49 @@
+package com.run_us.server.domains.crew.service;
+
+import com.run_us.server.domains.crew.controller.model.enums.CrewException;
+import com.run_us.server.domains.crew.controller.model.enums.CrewErrorCode;
+import com.run_us.server.domains.crew.domain.Crew;
+import com.run_us.server.domains.crew.domain.CrewJoinRequest;
+import com.run_us.server.domains.crew.domain.enums.CrewJoinType;
+import com.run_us.server.domains.crew.repository.CrewRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CrewService {
+    private final CrewRepository crewRepository;
+
+    public Crew getCrewByPublicId(String crewPublicId) {
+        log.debug("action=fetch_crew crewPublicId={}", crewPublicId);
+        return crewRepository.findByPublicId(crewPublicId)
+                .orElseThrow(() -> new CrewException(CrewErrorCode.CREW_NOT_FOUND));
+    }
+
+    @Transactional
+    public CrewJoinRequest createJoinRequest(Crew crew, Integer userInternalId, String answer) {
+        log.debug("action=create_join_request crewPublicId={} userInternalId={}", crew.getPublicId(), userInternalId);
+
+        CrewJoinRequest joinRequest = CrewJoinRequest.builder()
+                                                        .userId(userInternalId)
+                                                        .answer(answer)
+                                                        .build();
+
+        if (crew.getJoinType() == CrewJoinType.OPEN) {
+            log.debug("action=auto_approve_join_request crewPublicId={} userInternalId={}", crew.getPublicId(), userInternalId);
+            joinRequest.approve(crew.getOwner());
+            crew.addMember(userInternalId);
+        }
+
+        crew.addJoinRequest(joinRequest);
+        crewRepository.save(crew);
+
+        log.debug("action=create_join_request_complete crewPublicId={} userInternalId={} status={}",
+                crew.getPublicId(), userInternalId, joinRequest.getStatus());
+
+        return joinRequest;
+    }
+}

--- a/src/main/java/com/run_us/server/domains/crew/service/CrewService.java
+++ b/src/main/java/com/run_us/server/domains/crew/service/CrewService.java
@@ -43,4 +43,18 @@ public class CrewService {
 
         return joinRequest;
     }
+
+    @Transactional
+    public void cancelJoinRequest(Crew crew, Integer userInternalId) {
+        log.debug("action=cancel_join_request crewPublicId={} userInternalId={}", crew.getPublicId(), userInternalId);
+
+
+        CrewJoinRequest joinRequest = crewRepository.findWaitingJoinRequest(crew.getPublicId(), userInternalId)
+                .orElseThrow(() -> new CrewException(CrewErrorCode.JOIN_REQUEST_NOT_FOUND));
+
+        crew.removeJoinRequest(joinRequest);
+        crewRepository.save(crew);
+
+        log.debug("action=cancel_join_request_complete crewPublicId={} userInternalId={}", crew.getPublicId(), userInternalId);
+    }
 }

--- a/src/main/java/com/run_us/server/domains/crew/service/CrewValidator.java
+++ b/src/main/java/com/run_us/server/domains/crew/service/CrewValidator.java
@@ -1,0 +1,29 @@
+package com.run_us.server.domains.crew.service;
+
+import com.run_us.server.domains.crew.domain.Crew;
+import com.run_us.server.domains.crew.controller.model.enums.CrewException;
+import com.run_us.server.domains.crew.controller.model.enums.CrewErrorCode;
+
+import com.run_us.server.domains.crew.repository.CrewRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CrewValidator {
+    private final CrewRepository crewRepository;
+
+    public void validateCanJoinCrew(Integer userId, Crew crew) {
+        if (crew.isMember(userId)) {
+            throw new CrewException(CrewErrorCode.ALREADY_CREW_MEMBER);
+        }
+
+        if (crew.hasWaitingRequest(userId)) {
+            throw new CrewException(CrewErrorCode.DUPLICATE_JOIN_REQUEST);
+        }
+
+        if (!crew.isActive()) {
+            throw new CrewException(CrewErrorCode.INVALID_JOIN_REQUEST);
+        }
+    }
+}

--- a/src/main/java/com/run_us/server/domains/crew/service/usecase/CrewJoinUseCase.java
+++ b/src/main/java/com/run_us/server/domains/crew/service/usecase/CrewJoinUseCase.java
@@ -5,4 +5,5 @@ import com.run_us.server.domains.crew.controller.model.response.CrewJoinRequestI
 
 public interface CrewJoinUseCase {
     CrewJoinRequestInternalResponse createJoinRequest(String crewPublicId, Integer userId, CreateJoinRequest request);
+    CrewJoinRequestInternalResponse cancelJoinRequest(String crewPublicId, Integer userId);
 }

--- a/src/main/java/com/run_us/server/domains/crew/service/usecase/CrewJoinUseCase.java
+++ b/src/main/java/com/run_us/server/domains/crew/service/usecase/CrewJoinUseCase.java
@@ -1,0 +1,8 @@
+package com.run_us.server.domains.crew.service.usecase;
+
+import com.run_us.server.domains.crew.controller.model.request.CreateJoinRequest;
+import com.run_us.server.domains.crew.controller.model.response.CrewJoinRequestInternalResponse;
+
+public interface CrewJoinUseCase {
+    CrewJoinRequestInternalResponse createJoinRequest(String crewPublicId, Integer userId, CreateJoinRequest request);
+}

--- a/src/main/java/com/run_us/server/domains/crew/service/usecase/CrewJoinUseCaseImpl.java
+++ b/src/main/java/com/run_us/server/domains/crew/service/usecase/CrewJoinUseCaseImpl.java
@@ -1,0 +1,41 @@
+package com.run_us.server.domains.crew.service.usecase;
+
+import com.run_us.server.domains.crew.controller.model.request.CreateJoinRequest;
+import com.run_us.server.domains.crew.controller.model.response.CrewJoinRequestInternalResponse;
+import com.run_us.server.domains.crew.domain.Crew;
+import com.run_us.server.domains.crew.domain.CrewJoinRequest;
+import com.run_us.server.domains.crew.service.CrewService;
+import com.run_us.server.domains.crew.service.CrewValidator;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CrewJoinUseCaseImpl implements CrewJoinUseCase {
+    private final CrewService crewService;
+    private final CrewValidator crewValidator;
+
+    @Override
+    @Transactional
+    public CrewJoinRequestInternalResponse createJoinRequest(String crewPublicId, Integer userInternalId, CreateJoinRequest request) {
+        log.debug("action=create_join_request_start crewPublicId={} userInternalId={}", crewPublicId, userInternalId);
+
+        Crew crew = crewService.getCrewByPublicId(crewPublicId);
+        crewValidator.validateCanJoinCrew(userInternalId, crew);
+
+        CrewJoinRequest joinRequest = crewService.createJoinRequest(crew, userInternalId, request.getAnswer());
+
+        log.debug("action=create_join_request_end crewPublicId={} userInternalId={} status={}",
+                crewPublicId, userInternalId, joinRequest.getStatus());
+
+        return CrewJoinRequestInternalResponse.builder()
+                .crewPublicId(crewPublicId)
+                .userInternalId(userInternalId)
+                .status(joinRequest.getStatus())
+                .requestedAt(joinRequest.getRequestedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/run_us/server/domains/crew/service/usecase/CrewJoinUseCaseImpl.java
+++ b/src/main/java/com/run_us/server/domains/crew/service/usecase/CrewJoinUseCaseImpl.java
@@ -38,4 +38,22 @@ public class CrewJoinUseCaseImpl implements CrewJoinUseCase {
                 .requestedAt(joinRequest.getRequestedAt())
                 .build();
     }
+
+    @Override
+    @Transactional
+    public CrewJoinRequestInternalResponse cancelJoinRequest(String crewPublicId, Integer userInternalId) {
+        log.debug("action=cancel_join_request_start crewPublicId={} userInternalId={}", crewPublicId, userInternalId);
+
+        Crew crew = crewService.getCrewByPublicId(crewPublicId);
+        crewService.cancelJoinRequest(crew, userInternalId);
+
+        log.debug("action=cancel_join_request_end crewPublicId={} userInternalId={}", crewPublicId, userInternalId);
+
+        return CrewJoinRequestInternalResponse.builder()
+                .crewPublicId(crewPublicId)
+                .userInternalId(userInternalId)
+                .status(null)
+                .requestedAt(null)
+                .build();
+    }
 }

--- a/src/main/java/com/run_us/server/domains/user/exception/UserException.java
+++ b/src/main/java/com/run_us/server/domains/user/exception/UserException.java
@@ -9,7 +9,7 @@ public class UserException extends BusinessException {
     super(errorCode, logMessage);
   }
 
-  protected UserException(CustomResponseCode errorCode) {
+  public UserException(CustomResponseCode errorCode) {
     super(errorCode);
   }
 

--- a/src/main/java/com/run_us/server/global/config/CacheConfig.java
+++ b/src/main/java/com/run_us/server/global/config/CacheConfig.java
@@ -3,6 +3,7 @@ package com.run_us.server.global.config;
 import com.run_us.server.global.common.cache.InMemoryCache;
 import com.run_us.server.global.common.cache.SpringInMemoryCache;
 import com.run_us.server.domains.user.domain.TokenStatus;
+import com.run_us.server.global.security.principal.UserPrincipal;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -33,6 +34,14 @@ public class CacheConfig {
 
     @Bean
     public InMemoryCache<String, TokenStatus> tokenStatusCache(TaskScheduler cacheCleanupScheduler) {
+        return new SpringInMemoryCache<>(
+                cacheCleanupScheduler,
+                Duration.ofSeconds(cleanupIntervalSeconds)
+        );
+    }
+
+    @Bean
+    public InMemoryCache<String, UserPrincipal> userPrincipalCache(TaskScheduler cacheCleanupScheduler) {
         return new SpringInMemoryCache<>(
                 cacheCleanupScheduler,
                 Duration.ofSeconds(cleanupIntervalSeconds)

--- a/src/main/java/com/run_us/server/global/config/WebMvcConfig.java
+++ b/src/main/java/com/run_us/server/global/config/WebMvcConfig.java
@@ -1,0 +1,22 @@
+package com.run_us.server.global.config;
+
+import com.run_us.server.global.security.resolver.CurrentUserArgumentResolver;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+public class WebMvcConfig implements WebMvcConfigurer {
+    private final CurrentUserArgumentResolver currentUserResolver;
+
+    public WebMvcConfig(CurrentUserArgumentResolver currentUserResolver) {
+        this.currentUserResolver = currentUserResolver;
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(currentUserResolver);
+    }
+}

--- a/src/main/java/com/run_us/server/global/security/annotation/CurrentUser.java
+++ b/src/main/java/com/run_us/server/global/security/annotation/CurrentUser.java
@@ -1,0 +1,12 @@
+package com.run_us.server.global.security.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CurrentUser {
+    boolean required() default true;
+}

--- a/src/main/java/com/run_us/server/global/security/principal/UserPrincipal.java
+++ b/src/main/java/com/run_us/server/global/security/principal/UserPrincipal.java
@@ -1,0 +1,14 @@
+package com.run_us.server.global.security.principal;
+
+import lombok.Getter;
+
+@Getter
+public class UserPrincipal {
+    private final String publicId;
+    private final Integer internalId;
+
+    public UserPrincipal(String publicId, Integer userId) {
+        this.publicId = publicId;
+        this.internalId = userId;
+    }
+}

--- a/src/main/java/com/run_us/server/global/security/resolver/CurrentUserArgumentResolver.java
+++ b/src/main/java/com/run_us/server/global/security/resolver/CurrentUserArgumentResolver.java
@@ -1,0 +1,40 @@
+package com.run_us.server.global.security.resolver;
+
+import com.run_us.server.domains.user.exception.UserErrorCode;
+import com.run_us.server.domains.user.exception.UserException;
+import com.run_us.server.global.security.annotation.CurrentUser;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+@RequiredArgsConstructor
+public class CurrentUserArgumentResolver implements HandlerMethodArgumentResolver {
+    private final UserIdResolver userIdResolver;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(CurrentUser.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+        String userPublicId = extractUserPublicId();
+        return userIdResolver.resolveUser(userPublicId);
+    }
+
+    private String extractUserPublicId() throws UserException {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null) {
+            throw new UserException(UserErrorCode.JWT_BROKEN);
+        }
+        return authentication.getName();
+    }
+}

--- a/src/main/java/com/run_us/server/global/security/resolver/UserIdResolver.java
+++ b/src/main/java/com/run_us/server/global/security/resolver/UserIdResolver.java
@@ -1,0 +1,39 @@
+package com.run_us.server.global.security.resolver;
+
+import com.run_us.server.domains.user.domain.User;
+import com.run_us.server.domains.user.exception.UserErrorCode;
+import com.run_us.server.domains.user.exception.UserException;
+import com.run_us.server.domains.user.repository.UserRepository;
+import com.run_us.server.global.common.cache.InMemoryCache;
+import com.run_us.server.global.security.principal.UserPrincipal;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+
+@Component
+public class UserIdResolver {
+    private final InMemoryCache<String, UserPrincipal> principalCache;
+    private final UserRepository userRepository;
+
+    private static final Duration CACHE_TTL = Duration.ofMinutes(30);
+
+    public UserIdResolver(InMemoryCache<String, UserPrincipal> principalCache,
+                          UserRepository userRepository) {
+        this.principalCache = principalCache;
+        this.userRepository = userRepository;
+    }
+
+    public UserPrincipal resolveUser(String publicId) {
+        return principalCache.get(publicId)
+                .orElseGet(() -> loadAndCacheUserPrincipal(publicId));
+    }
+
+    private UserPrincipal loadAndCacheUserPrincipal(String publicId) {
+        User user = userRepository.findByPublicId(publicId)
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+
+        UserPrincipal principal = new UserPrincipal(publicId, user.getId());
+        principalCache.put(publicId, principal, CACHE_TTL);
+        return principal;
+    }
+}

--- a/src/main/java/com/run_us/server/global/security/resolver/UserIdResolver.java
+++ b/src/main/java/com/run_us/server/global/security/resolver/UserIdResolver.java
@@ -6,22 +6,18 @@ import com.run_us.server.domains.user.exception.UserException;
 import com.run_us.server.domains.user.repository.UserRepository;
 import com.run_us.server.global.common.cache.InMemoryCache;
 import com.run_us.server.global.security.principal.UserPrincipal;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.time.Duration;
 
 @Component
+@RequiredArgsConstructor
 public class UserIdResolver {
     private final InMemoryCache<String, UserPrincipal> principalCache;
     private final UserRepository userRepository;
 
     private static final Duration CACHE_TTL = Duration.ofMinutes(30);
-
-    public UserIdResolver(InMemoryCache<String, UserPrincipal> principalCache,
-                          UserRepository userRepository) {
-        this.principalCache = principalCache;
-        this.userRepository = userRepository;
-    }
 
     public UserPrincipal resolveUser(String publicId) {
         return principalCache.get(publicId)


### PR DESCRIPTION
### 연관된 이슈를 적어주세요 📌

JIS-107

### 작업한 내용을 설명해주세요 ✔️

> 어딘가 이상한건 아는데, 코드 컨벤션이 크게 바꼈다보니 피드백 받는용으로 초안 빨리 올려봅니다.
> JIS-107은 가입요청과 취소 2가지를 구현해야하는데, 우선 요청까지만 푸시했고, 취소는 피드백 이후 업데이트 예정입니다.

- 현재 로그인한 사용자 정보를 받아오기 위한 `@CurrentUser` 어노테이션 구현
  - PublicId와 InternalId만을 가지는 가벼운 객체인 UserPrincipal 생성
  - Security의 책임과 User-Auth 강결합 구조 사이에서 타협해서 UserIdResolver에게 예외적인 UserRepository 적용
  - 컨트롤러에서 `@CurrentUser UserPrincipal userPrincipal` 형식으로 사용하면 됩니다.
- 크루 가입요청 엔드포인트 구현
  - 외부 노출경계인 컨트롤러만 userPublicId 정보 활용 / 내부 로직부터는 userInternalId만 사용
  - 이로인해
    - 내부용 DTO `CrewJoinRequestInternalResponse` 분리
    - useCase가 아닌 컨트롤러가 SuccessResponse 생성
  - 상세사유
    - UseCase부터는 순수한 비즈니스 로직을 담당하기에 userInternalId가 타당
    - userPrincipal 객체는 웹 계층의 구현이기에, ID 변환의 책임은 표현계층인 컨트롤러에게 있음

### 리뷰어에게 하고 싶은 말을 적어주세요

- 위에도 적어놨지만,, 엔티티 오늘 머지되기 전에 미리 작업하던걸 피드백 용으로 빠르게 업로드한거라 코드가 좀 우당탕탕입니다.
- 아직도 UseCase와 Service의 명확한 구분을 모르겠읍니다,,, Somebody help me