### PR TITLE
[feat/create-crew] 크루 생성 api 구현

### DIFF
--- a/src/main/java/com/run_us/server/domains/crew/controller/CrewController.java
+++ b/src/main/java/com/run_us/server/domains/crew/controller/CrewController.java
@@ -1,0 +1,31 @@
+package com.run_us.server.domains.crew.controller;
+
+import com.run_us.server.domains.crew.controller.model.request.CreateCrewRequest;
+import com.run_us.server.domains.crew.controller.model.response.CrewHttpResponseCode;
+import com.run_us.server.domains.crew.controller.model.response.CreateCrewResponse;
+import com.run_us.server.domains.crew.service.usecase.CreateCrewUseCase;
+import com.run_us.server.global.common.SuccessResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/crews")
+public class CrewController {
+    private final CreateCrewUseCase createCrewUseCase;
+
+    @PostMapping
+    public ResponseEntity<SuccessResponse<CreateCrewResponse>> createCrew(
+            @RequestBody CreateCrewRequest requestDto,
+            @RequestAttribute("publicUserId") String userId) {
+        log.info("action=create_crew user_id={}", userId);
+
+        SuccessResponse<CreateCrewResponse> response = createCrewUseCase.createCrew(requestDto, userId);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+}

--- a/src/main/java/com/run_us/server/domains/crew/controller/model/request/CreateCrewRequest.java
+++ b/src/main/java/com/run_us/server/domains/crew/controller/model/request/CreateCrewRequest.java
@@ -1,0 +1,47 @@
+package com.run_us.server.domains.crew.controller.model.request;
+
+import com.run_us.server.domains.crew.domain.Crew;
+import com.run_us.server.domains.crew.domain.CrewDescription;
+import com.run_us.server.domains.crew.domain.CrewMembership;
+import com.run_us.server.domains.crew.domain.enums.CrewJoinType;
+import com.run_us.server.domains.crew.domain.enums.CrewMembershipRole;
+import com.run_us.server.domains.crew.domain.enums.CrewThemeType;
+import com.run_us.server.domains.user.domain.User;
+import lombok.*;
+
+import java.util.List;
+
+// TODO : 필드별 제약조건 설정
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CreateCrewRequest {
+    private String title;
+    private String profileImage;
+    private String location;
+    private String intro;
+    private String crewType;
+    private String joinType;
+    private String joinQuestion;
+    private String ownerId;
+
+    public Crew toEntity(User creator) {
+        CrewDescription description = CrewDescription.builder()
+                .title(this.title)
+                .profileImageUrl(this.profileImage)
+                .location(this.location)
+                .intro(this.intro)
+                .themeType(CrewThemeType.valueOf(this.crewType))
+                .joinQuestion(this.joinQuestion)
+                .build();
+        CrewMembership ownerMembership = CrewMembership.builder()
+                .userId(creator.getId())
+                .role(CrewMembershipRole.OWNER)
+                .build();
+        return Crew.builder()
+                .crewDescription(description)
+                .joinType(CrewJoinType.valueOf(this.joinType))
+                .owner(creator)
+                .crewMemberships(List.of(ownerMembership))
+                .build();
+    }
+}

--- a/src/main/java/com/run_us/server/domains/crew/controller/model/response/CreateCrewResponse.java
+++ b/src/main/java/com/run_us/server/domains/crew/controller/model/response/CreateCrewResponse.java
@@ -1,0 +1,27 @@
+package com.run_us.server.domains.crew.controller.model.response;
+
+import com.run_us.server.domains.crew.domain.Crew;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CreateCrewResponse {
+    private String crewPublicId;
+
+    @Builder
+    private CreateCrewResponse(String crewPublicId) {
+        this.crewPublicId = crewPublicId;
+    }
+
+    public static CreateCrewResponse from(Crew crew) {
+        return CreateCrewResponse.builder()
+                .crewPublicId(crew.getPublicId())
+                .build();
+    }
+
+    // builder?
+}

--- a/src/main/java/com/run_us/server/domains/crew/controller/model/response/CreateCrewResponse.java
+++ b/src/main/java/com/run_us/server/domains/crew/controller/model/response/CreateCrewResponse.java
@@ -22,6 +22,4 @@ public class CreateCrewResponse {
                 .crewPublicId(crew.getPublicId())
                 .build();
     }
-
-    // builder?
 }

--- a/src/main/java/com/run_us/server/domains/crew/domain/Crew.java
+++ b/src/main/java/com/run_us/server/domains/crew/domain/Crew.java
@@ -7,7 +7,6 @@ import com.run_us.server.global.common.DateAudit;
 import io.hypersistence.tsid.TSID;
 import jakarta.persistence.*;
 import lombok.*;
-import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.SQLRestriction;
 
 import java.time.LocalDateTime;
@@ -17,7 +16,7 @@ import java.util.List;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-@Table(name = "crews")
+@Table(name = "crew")
 @SQLRestriction("deleted_at is null")
 public class Crew extends DateAudit {
     @Id
@@ -31,7 +30,6 @@ public class Crew extends DateAudit {
     @JoinColumn(name = "owner_id", nullable = false)
     private User owner;
 
-    @ColumnDefault("0")
     @Column(nullable = false)
     private int memberCount;
 
@@ -41,7 +39,7 @@ public class Crew extends DateAudit {
 
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
-    private CrewStatus status = CrewStatus.ACTIVE;
+    private CrewStatus status;
 
     @Embedded
     private CrewDescription crewDescription;
@@ -54,7 +52,7 @@ public class Crew extends DateAudit {
     @CollectionTable(name = "crew_memberships", joinColumns = @JoinColumn(name="crew_id"))
     private List<CrewMembership> crewMemberships;
 
-    @Column(name = "deleted_at", nullable = false)
+    @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
 
 
@@ -74,6 +72,8 @@ public class Crew extends DateAudit {
         this.owner = owner;
         this.joinType = joinType;
         this.crewDescription = crewDescription;
+        this.memberCount = 1;
+        this.status = CrewStatus.ACTIVE;
         this.crewMemberships = crewMemberships;
     }
 }

--- a/src/main/java/com/run_us/server/domains/crew/domain/CrewJoinRequest.java
+++ b/src/main/java/com/run_us/server/domains/crew/domain/CrewJoinRequest.java
@@ -9,8 +9,11 @@ import lombok.NoArgsConstructor;
 import lombok.ToString;
 import org.hibernate.annotations.SQLRestriction;
 
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Objects;
+
+import static com.run_us.server.global.common.GlobalConst.TIME_ZONE_ID;
 
 @ToString
 @Getter
@@ -25,10 +28,10 @@ public class CrewJoinRequest {
 
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
-    private CrewJoinRequestStatus status;
+    private CrewJoinRequestStatus status = CrewJoinRequestStatus.WAITING;
 
     @Column(name = "requested_at", nullable = false)
-    private ZonedDateTime requestedAt;
+    private ZonedDateTime requestedAt = ZonedDateTime.now(ZoneId.of(TIME_ZONE_ID));
 
     @Column(name = "processed_at")
     private ZonedDateTime processedAt;

--- a/src/main/java/com/run_us/server/domains/crew/domain/CrewMembership.java
+++ b/src/main/java/com/run_us/server/domains/crew/domain/CrewMembership.java
@@ -28,12 +28,7 @@ public class CrewMembership {
     private CrewMembershipRole role;
 
     @Column(name = "joined_at", nullable = false)
-    private ZonedDateTime joinedAt;
-
-    @PrePersist
-    public void prePersist() {
-        this.joinedAt = ZonedDateTime.now(ZoneId.of(TIME_ZONE_ID));
-    }
+    private ZonedDateTime joinedAt = ZonedDateTime.now(ZoneId.of(TIME_ZONE_ID));
 
     @Builder
     public CrewMembership(

--- a/src/main/java/com/run_us/server/domains/crew/repository/CrewRepository.java
+++ b/src/main/java/com/run_us/server/domains/crew/repository/CrewRepository.java
@@ -1,0 +1,9 @@
+package com.run_us.server.domains.crew.repository;
+
+import com.run_us.server.domains.crew.domain.Crew;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CrewRepository extends JpaRepository<Crew, Long> {
+}

--- a/src/main/java/com/run_us/server/domains/crew/service/CrewCommandService.java
+++ b/src/main/java/com/run_us/server/domains/crew/service/CrewCommandService.java
@@ -1,0 +1,20 @@
+package com.run_us.server.domains.crew.service;
+
+import com.run_us.server.domains.crew.controller.model.request.CreateCrewRequest;
+import com.run_us.server.domains.crew.domain.Crew;
+import com.run_us.server.domains.crew.repository.CrewRepository;
+import com.run_us.server.domains.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CrewCommandService {
+
+    private final CrewRepository crewRepository;
+
+    public Crew saveCrew(CreateCrewRequest requestDto, User creator) {
+        Crew crew = requestDto.toEntity(creator);
+        return crewRepository.save(crew);
+    }
+}

--- a/src/main/java/com/run_us/server/domains/crew/service/usecase/CreateCrewUseCase.java
+++ b/src/main/java/com/run_us/server/domains/crew/service/usecase/CreateCrewUseCase.java
@@ -1,0 +1,9 @@
+package com.run_us.server.domains.crew.service.usecase;
+
+import com.run_us.server.domains.crew.controller.model.request.CreateCrewRequest;
+import com.run_us.server.domains.crew.controller.model.response.CreateCrewResponse;
+import com.run_us.server.global.common.SuccessResponse;
+
+public interface CreateCrewUseCase {
+    SuccessResponse<CreateCrewResponse> createCrew(CreateCrewRequest requestDto, String creatorId);
+}

--- a/src/main/java/com/run_us/server/domains/crew/service/usecase/CreateCrewUseCaseImpl.java
+++ b/src/main/java/com/run_us/server/domains/crew/service/usecase/CreateCrewUseCaseImpl.java
@@ -1,8 +1,8 @@
 package com.run_us.server.domains.crew.service.usecase;
 
+import com.run_us.server.domains.crew.controller.model.enums.CrewHttpResponseCode;
 import com.run_us.server.domains.crew.controller.model.request.CreateCrewRequest;
 import com.run_us.server.domains.crew.controller.model.response.CreateCrewResponse;
-import com.run_us.server.domains.crew.controller.model.response.CrewHttpResponseCode;
 import com.run_us.server.domains.crew.domain.Crew;
 import com.run_us.server.domains.crew.service.CrewCommandService;
 import com.run_us.server.domains.user.domain.User;

--- a/src/main/java/com/run_us/server/domains/crew/service/usecase/CreateCrewUseCaseImpl.java
+++ b/src/main/java/com/run_us/server/domains/crew/service/usecase/CreateCrewUseCaseImpl.java
@@ -1,0 +1,31 @@
+package com.run_us.server.domains.crew.service.usecase;
+
+import com.run_us.server.domains.crew.controller.model.request.CreateCrewRequest;
+import com.run_us.server.domains.crew.controller.model.response.CreateCrewResponse;
+import com.run_us.server.domains.crew.controller.model.response.CrewHttpResponseCode;
+import com.run_us.server.domains.crew.domain.Crew;
+import com.run_us.server.domains.crew.service.CrewCommandService;
+import com.run_us.server.domains.user.domain.User;
+import com.run_us.server.domains.user.service.UserService;
+import com.run_us.server.global.common.SuccessResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class CreateCrewUseCaseImpl implements CreateCrewUseCase {
+
+    private final UserService userService;
+    private final CrewCommandService crewCommandService;
+
+    @Override
+    @Transactional
+    public SuccessResponse<CreateCrewResponse> createCrew(CreateCrewRequest requestDto, String creatorId) {
+        User creator = userService.getUserByPublicId(creatorId);
+        Crew crew = crewCommandService.saveCrew(requestDto, creator);
+
+        return SuccessResponse.of(CrewHttpResponseCode.CREW_CREATED, CreateCrewResponse.from(crew));
+    }
+}

--- a/src/test/java/com/run_us/server/domains/crew/domain/CrewFixtures.java
+++ b/src/test/java/com/run_us/server/domains/crew/domain/CrewFixtures.java
@@ -1,0 +1,52 @@
+package com.run_us.server.domains.crew.domain;
+
+import com.run_us.server.domains.crew.domain.enums.CrewJoinType;
+import com.run_us.server.domains.crew.domain.enums.CrewMembershipRole;
+import com.run_us.server.domains.crew.domain.enums.CrewThemeType;
+import com.run_us.server.domains.user.domain.User;
+import com.run_us.server.domains.user.domain.UserFixtures;
+
+import java.util.List;
+
+public final class CrewFixtures {
+
+    /**
+     * 크루장이 크루를 처음 개설했을 때의 Crew 엔티티 반환
+     * @return
+     */
+    public static Crew createInitalCrew(String ownerNickname, String crewTitle, String crewIntro) {
+        User owner = UserFixtures.getDefaultUserWithNickname(ownerNickname);
+        Crew crew = Crew.builder()
+                .owner(owner)
+                .crewDescription(createCrewDescription(crewTitle, crewIntro))
+                .crewMemberships(createOwnerOnlyCrewMemberships(owner))
+                .joinType(CrewJoinType.OPEN)
+                .build();
+        return crew;
+    }
+
+    private static CrewDescription createCrewDescription(String crewTitle, String crewIntro) {
+        // 필수값만 넣음
+        return CrewDescription.builder()
+                .title(crewTitle)
+                .intro(crewIntro)
+                .location(null)
+                .themeType(CrewThemeType.LOCAL_MATE)
+                .joinQuestion(null)
+                .profileImageUrl(null)
+                .build();
+    }
+
+    /**
+     * 크루장만 포함된 회원 목록 반환
+     * @param user
+     * @return
+     */
+    private static List<CrewMembership> createOwnerOnlyCrewMemberships(User user) {
+        CrewMembership ownerMembership = CrewMembership.builder()
+                .userId(user.getId())
+                .role(CrewMembershipRole.OWNER)
+                .build();
+        return List.of(ownerMembership);
+    }
+}

--- a/src/test/java/com/run_us/server/domains/crew/domain/CrewTest.java
+++ b/src/test/java/com/run_us/server/domains/crew/domain/CrewTest.java
@@ -1,0 +1,27 @@
+package com.run_us.server.domains.crew.domain;
+
+import com.run_us.server.domains.crew.domain.enums.CrewMembershipRole;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CrewTest {
+
+    @DisplayName("크루 초기 생성 테스트")
+    @Test
+    void test_create_initial_crew() {
+        String ownerNickname = "달려라 하니";
+        String crewTitle = "빵빵런";
+        String crewIntro = "러닝하고 빵먹고";
+        Crew crew = CrewFixtures.createInitalCrew(ownerNickname, crewTitle, crewIntro);
+
+        assertNotNull(crew);
+        assertEquals(crew.getOwner().getProfile().getNickname(), ownerNickname);
+        assertEquals(crew.getCrewDescription().getTitle(), crewTitle);
+        assertEquals(crew.getCrewDescription().getIntro(), crewIntro);
+        assertEquals(crew.getCrewMemberships().size(), 1);
+        assertEquals(crew.getCrewMemberships().get(0).getRole(), CrewMembershipRole.OWNER);
+    }
+
+}


### PR DESCRIPTION
### 연관된 이슈를 적어주세요 📌
close #<issue_num>

### 작업한 내용을 설명해주세요 ✔️

- 크루 생성 api 구현입니다.
- 최근 merge 된 PR 에 현재님이 만들어주신 @CurrentUser 어노테이션이 있었죠.
그거 올라오기 전부터 짜던 코드라 해당 어노테이션을 사용하지 않고 있었고, 사용하는 걸로 변경하려다가 의문이 한가지 들어서
일단 적용하지 않고 올립니다. 질문 결과에 따라 다음 PR에서 수정하겠습니다.

[의문]
1. 지금 @CurrentUser 는 사용자의 public id 로 DB 에서 User 를 조회해 public, internal Id 만 컨트롤러에 전달해주고 있는데요.
id에 해당하는 User 객체가 필요하면 DB를 한번 더 다녀와야 하는 상황입니다.
User 를 통으로 담지 않음으로써 도메인 의존을 줄이는 대신 쿼리를 한번 더 날리는 게 바람직한.. 방향이 맞겠죠?
2. internal id 를 받아왔는데 public id 를 사용할 일이 있을까요? UserPrincipal 에 public id 도 담는 것이 효용성이 있을지 궁금합니다.

감사합니다.



### 트러블 슈팅

### 리뷰어에게 하고 싶은 말을 적어주세요

### 확인하기

- [ ] : 코드에 에러가 없는지 확인했나요?
- [ ] : PR에 설명을 기재했나요?
- [ ] : PR 태그를 붙였나요?
- [ ] : 불필요한 로그나 `System.out`을 제거했나요?