### PR TITLE
[Feat/fetch-joined-running] - 참가한 러닝 조회

### DIFF
--- a/src/main/java/com/run_us/server/domains/running/run/controller/RunController.java
+++ b/src/main/java/com/run_us/server/domains/running/run/controller/RunController.java
@@ -2,12 +2,10 @@ package com.run_us.server.domains.running.run.controller;
 
 import com.run_us.server.domains.running.run.controller.model.RunningHttpResponseCode;
 import com.run_us.server.domains.running.run.controller.model.request.SessionRunCreateRequest;
-import com.run_us.server.domains.running.run.service.model.CustomRunCreateResponse;
-import com.run_us.server.domains.running.run.service.model.FetchRunningIdResponse;
-import com.run_us.server.domains.running.run.service.model.ParticipantInfo;
-import com.run_us.server.domains.running.run.service.model.SessionRunCreateResponse;
+import com.run_us.server.domains.running.run.service.model.*;
 import com.run_us.server.domains.running.run.service.usecase.RunCreateUseCase;
 import com.run_us.server.domains.running.run.service.usecase.RunDeleteUseCase;
+import com.run_us.server.domains.running.run.service.usecase.RunPreviewUseCase;
 import com.run_us.server.domains.running.run.service.usecase.RunRegisterUseCase;
 import com.run_us.server.global.common.SuccessResponse;
 import lombok.RequiredArgsConstructor;
@@ -26,6 +24,7 @@ public class RunController {
 
   private final RunCreateUseCase runCreateUseCase;
   private final RunRegisterUseCase runRegisterUseCase;
+  private final RunPreviewUseCase runPreviewUseCase;
   private final RunDeleteUseCase runDeleteUseCase;
 
   @PostMapping(params = "mode=custom")
@@ -41,7 +40,7 @@ public class RunController {
       @RequestBody SessionRunCreateRequest runningCreateRequest,
       @RequestAttribute("publicUserId") String userId) {
     log.info("action=create_session_running user_id={}", userId);
-    SuccessResponse<SessionRunCreateResponse> response = runCreateUseCase.saveNewSessionRun(userId, runningCreateRequest.toRunningPreview());
+    SuccessResponse<SessionRunCreateResponse> response = runCreateUseCase.saveNewSessionRun(userId, runningCreateRequest.toRunCreateDto());
     return ResponseEntity.status(HttpStatus.CREATED).body(response);
   }
 
@@ -76,5 +75,15 @@ public class RunController {
     log.info("action=delete_running running_id={} user_id={}", runningId, userId);
     runDeleteUseCase.deleteRun(userId, runningId);
     return ResponseEntity.ok(SuccessResponse.messageOnly(RunningHttpResponseCode.RUN_PREVIEW_DELETED));
+  }
+
+  @GetMapping("/registrations")
+  public ResponseEntity<SuccessResponse<List<JoinedRunPreviewResponse>>> getJoinedRunnings(
+      @RequestAttribute("publicUserId") String userId,
+      @RequestParam(defaultValue = "0") int runningPage,
+      @RequestParam(defaultValue = "10") int runningSize){
+    log.info("action=get_joined_runnings user_id={}", userId);
+    SuccessResponse<List<JoinedRunPreviewResponse>> response = runPreviewUseCase.getJoinedRunPreview(userId, runningPage, runningSize);
+    return ResponseEntity.ok().body(response);
   }
 }

--- a/src/main/java/com/run_us/server/domains/running/run/controller/model/request/SessionRunCreateRequest.java
+++ b/src/main/java/com/run_us/server/domains/running/run/controller/model/request/SessionRunCreateRequest.java
@@ -3,13 +3,14 @@ package com.run_us.server.domains.running.run.controller.model.request;
 import com.run_us.server.domains.running.common.RunningErrorCode;
 import com.run_us.server.domains.running.common.RunningException;
 import com.run_us.server.domains.running.run.domain.RunPace;
-import com.run_us.server.domains.running.run.domain.RunningPreview;
+import com.run_us.server.domains.running.run.service.model.RunCreateDto;
 import com.run_us.server.global.validator.annotation.EnumValid;
 import lombok.Builder;
 import lombok.Getter;
 
 import java.time.ZonedDateTime;
 import java.util.List;
+import java.util.Set;
 
 @Getter
 public class SessionRunCreateRequest {
@@ -21,7 +22,7 @@ public class SessionRunCreateRequest {
   private final SessionAccessLevel accessLevel;
   private final String crewPublicId;
   @EnumValid(enumClass = RunPace.class)
-  private final List<RunPace> paceCategories;
+  private final Set<RunPace> paceCategories;
 
   @Builder
   public SessionRunCreateRequest(
@@ -31,7 +32,7 @@ public class SessionRunCreateRequest {
       String meetingPlace,
       SessionAccessLevel accessLevel,
       String crewPublicId,
-      List<RunPace> paceCategories) {
+      Set<RunPace> paceCategories) {
     validateCrewPublicId(accessLevel, crewPublicId);
     validatePace(paceCategories);
     this.title = title;
@@ -43,15 +44,8 @@ public class SessionRunCreateRequest {
     this.paceCategories = paceCategories;
   }
 
-  public RunningPreview toRunningPreview() {
-    return RunningPreview.builder()
-        .title(title)
-        .description(description)
-        .beginTime(startDateTime)
-        .meetingPoint(meetingPlace)
-        .accessLevel(accessLevel)
-        .paceCategories(paceCategories)
-        .build();
+  public RunCreateDto toRunCreateDto() {
+    return new RunCreateDto(title, description, meetingPlace, accessLevel, startDateTime, List.copyOf(paceCategories));
   }
 
   // 크루 공개일 경우 크루 아이디가 필수
@@ -61,7 +55,7 @@ public class SessionRunCreateRequest {
     }
   }
 
-  private void validatePace(List<RunPace> pace) {
+  private void validatePace(Set<RunPace> pace) {
     if(pace != null && pace.size() > 3) {
       throw RunningException.of(RunningErrorCode.RUNNING_SESSION_INVALID);
     }

--- a/src/main/java/com/run_us/server/domains/running/run/domain/Run.java
+++ b/src/main/java/com/run_us/server/domains/running/run/domain/Run.java
@@ -9,6 +9,8 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 @Entity
 @Table(name = "run")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -26,6 +28,11 @@ public class Run extends CreationTimeAudit {
 
   @Enumerated(EnumType.STRING)
   private RunStatus status;
+
+  @ElementCollection(targetClass = RunPace.class)
+  @CollectionTable(name = "run_pace", joinColumns = @JoinColumn(name = "run_id"))
+  @Enumerated(EnumType.STRING)
+  List<RunPace> paceCategories;
 
   @Embedded private RunningPreview preview;
 
@@ -59,8 +66,8 @@ public class Run extends CreationTimeAudit {
     return this.hostId.equals(userId);
   }
 
-  public boolean isJoinable() {
-    return RunStatus.isJoinable(this.status);
+  public void modifyPaceInfo(List<RunPace> runPaces) {
+    this.paceCategories = runPaces;
   }
 
   private void validateRunModifiable() {

--- a/src/main/java/com/run_us/server/domains/running/run/domain/RunningPreview.java
+++ b/src/main/java/com/run_us/server/domains/running/run/domain/RunningPreview.java
@@ -1,9 +1,8 @@
 package com.run_us.server.domains.running.run.domain;
 
 import com.run_us.server.domains.running.run.controller.model.request.SessionAccessLevel;
-import jakarta.persistence.ElementCollection;
+import com.run_us.server.domains.running.run.service.model.RunCreateDto;
 import jakarta.persistence.Embeddable;
-import jakarta.persistence.Enumerated;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,8 +10,6 @@ import lombok.NoArgsConstructor;
 
 import java.io.Serializable;
 import java.time.ZonedDateTime;
-import java.util.ArrayList;
-import java.util.List;
 
 @Embeddable
 @Getter
@@ -21,9 +18,6 @@ public class RunningPreview implements Serializable {
   private String title;
   private String description;
   private String meetingPoint;
-  @ElementCollection(targetClass = RunPace.class)
-  @Enumerated
-  private List<RunPace> paceCategories = new ArrayList<>();
   private SessionAccessLevel accessLevel;
   private ZonedDateTime beginTime;
 
@@ -32,14 +26,22 @@ public class RunningPreview implements Serializable {
       String title,
       String description,
       String meetingPoint,
-      List<RunPace> paceCategories,
       SessionAccessLevel accessLevel,
       ZonedDateTime beginTime) {
     this.title = title;
     this.description = description;
     this.meetingPoint = meetingPoint;
-    this.paceCategories = paceCategories;
     this.accessLevel = accessLevel;
     this.beginTime = beginTime;
+  }
+
+  public static RunningPreview from(RunCreateDto runCreateDto) {
+    return RunningPreview.builder()
+        .title(runCreateDto.getTitle())
+        .description(runCreateDto.getDescription())
+        .meetingPoint(runCreateDto.getMeetingPoint())
+        .accessLevel(runCreateDto.getAccessLevel())
+        .beginTime(runCreateDto.getBeginTime())
+        .build();
   }
 }

--- a/src/main/java/com/run_us/server/domains/running/run/repository/RunRepository.java
+++ b/src/main/java/com/run_us/server/domains/running/run/repository/RunRepository.java
@@ -1,11 +1,15 @@
 package com.run_us.server.domains.running.run.repository;
 
 import com.run_us.server.domains.running.run.domain.Run;
+import com.run_us.server.domains.running.run.service.model.JoinedRunPreviewResponse;
 import com.run_us.server.domains.running.run.service.model.GetRunPreviewResponse;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -16,8 +20,28 @@ public interface RunRepository extends JpaRepository<Run, Integer> {
       "SELECT new com.run_us.server.domains.running.run.service.model.GetRunPreviewResponse"
           + "(u.profile.nickname, u.profile.imgUrl, r.preview) "
           + "FROM Run r "
-          + "join fetch r.preview.paceCategories "
+          + "join r.paceCategories "
           + "left join User u on r.hostId = u.id "
           + "WHERE r.id = :runId")
   GetRunPreviewResponse findByRunId(Integer runId);
+
+
+  @Query(
+      "SELECT new com.run_us.server.domains.running.run.service.model.JoinedRunPreviewResponse"
+          + "(r.publicId, r.preview, COUNT(distinct p2.userId), u.publicId, pr.nickname, pr.imgUrl) "
+          + "FROM Run r "
+          + "join Participant p on r.id = p.run.id and p.userId = :userId "
+          + "left join Participant p2 on r.id = p2.run.id "
+          + "left join User u on r.hostId = u.id "
+          + "left join Profile pr on u.id = pr.id "
+          + "GROUP BY r.publicId, r.preview, pr.nickname, pr.imgUrl, u.publicId")
+  Slice<JoinedRunPreviewResponse> findJoinedRunPreviews(Integer userId, PageRequest pageRequest);
+
+  @Query(
+      "SELECT r "
+          + "FROM Run r "
+          + "join fetch r.paceCategories "
+          + "WHERE r.publicId IN :keys")
+  List<Run> findAllByPublicId(List<String> keys);
+
 }

--- a/src/main/java/com/run_us/server/domains/running/run/service/RunCommandService.java
+++ b/src/main/java/com/run_us/server/domains/running/run/service/RunCommandService.java
@@ -4,6 +4,7 @@ import com.run_us.server.domains.running.run.domain.Run;
 import com.run_us.server.domains.running.run.domain.RunStatus;
 import com.run_us.server.domains.running.run.domain.RunningPreview;
 import com.run_us.server.domains.running.run.repository.RunRepository;
+import com.run_us.server.domains.running.run.service.model.RunCreateDto;
 import com.run_us.server.domains.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -16,9 +17,16 @@ public class RunCommandService {
   private final RunValidator runValidator;
   private final RunQueryService runQueryService;
 
-  public Run saveNewRun(User user, RunningPreview preview) {
+  public Run saveNewRun(User user, RunCreateDto createDto) {
     Run run = new Run(user.getId());
+    RunningPreview preview = RunningPreview.from(createDto);
     run.modifySessionInfo(preview);
+    run.modifyPaceInfo(createDto.getRunPaces());
+    return runRepository.save(run);
+  }
+
+  public Run saveNewCustomRun(User user) {
+    Run run = new Run(user.getId());
     return runRepository.save(run);
   }
 

--- a/src/main/java/com/run_us/server/domains/running/run/service/RunQueryService.java
+++ b/src/main/java/com/run_us/server/domains/running/run/service/RunQueryService.java
@@ -4,9 +4,16 @@ import com.run_us.server.domains.running.common.RunningErrorCode;
 import com.run_us.server.domains.running.common.RunningException;
 import com.run_us.server.domains.running.run.domain.Run;
 import com.run_us.server.domains.running.run.repository.RunRepository;
+import com.run_us.server.domains.running.run.service.model.JoinedRunPreviewResponse;
 import com.run_us.server.domains.running.run.service.model.GetRunPreviewResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Component
 @RequiredArgsConstructor
@@ -28,5 +35,23 @@ public class RunQueryService {
 
   public GetRunPreviewResponse getRunPreviewById(Integer runId) {
     return runRepository.findByRunId(runId);
+  }
+
+  // 2가지 쿼리 발생 : 1. 세션 정보 2. 페이스 태그 정보
+  public List<JoinedRunPreviewResponse> getJoinedRunPreviews(Integer userId, Integer page, Integer size) {
+    PageRequest pageRequest = PageRequest.of(page, size);
+    Map<String, JoinedRunPreviewResponse> previews =  runRepository.findJoinedRunPreviews(userId, pageRequest)
+        .stream()
+        .collect(Collectors.toMap(JoinedRunPreviewResponse::getRunningPublicId, preview -> preview));
+    List<Run> runs = runRepository.findAllByPublicId(previews.keySet().stream().toList());
+    updateJoinedRunPreviewWithPaceTypes(runs, previews);
+    return new ArrayList<>(previews.values());
+  }
+
+  private void updateJoinedRunPreviewWithPaceTypes(List<Run> runs, Map<String, JoinedRunPreviewResponse> previews) {
+    for (Run run : runs) {
+      JoinedRunPreviewResponse preview = previews.get(run.getPublicId());
+      preview.setRunPaces(run.getPaceCategories());
+    }
   }
 }

--- a/src/main/java/com/run_us/server/domains/running/run/service/model/HostInfo.java
+++ b/src/main/java/com/run_us/server/domains/running/run/service/model/HostInfo.java
@@ -1,0 +1,16 @@
+package com.run_us.server.domains.running.run.service.model;
+
+import lombok.Getter;
+
+@Getter
+public class HostInfo {
+  private String userPublicId;
+  private String name;
+  private String imgUrl;
+
+  public HostInfo(String userPublicId, String name, String imgUrl) {
+    this.userPublicId = userPublicId;
+    this.name = name;
+    this.imgUrl = imgUrl;
+  }
+}

--- a/src/main/java/com/run_us/server/domains/running/run/service/model/JoinedRunPreviewResponse.java
+++ b/src/main/java/com/run_us/server/domains/running/run/service/model/JoinedRunPreviewResponse.java
@@ -1,0 +1,36 @@
+package com.run_us.server.domains.running.run.service.model;
+
+import com.run_us.server.domains.running.run.domain.RunPace;
+import com.run_us.server.domains.running.run.domain.RunningPreview;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.ZonedDateTime;
+import java.util.List;
+
+@Getter
+public class JoinedRunPreviewResponse {
+  private String runningPublicId;
+  private String title;
+  private String description;
+  private ZonedDateTime startAt;
+  private Long participantCount;
+  private HostInfo createdBy;
+  @Setter
+  private List<RunPace> runPaces;
+
+  public JoinedRunPreviewResponse(String runningPublicId,
+                                  RunningPreview runningPreview,
+                                  Long participantCount,
+                                  String userPublicId, String name, String imgUrl) {
+    this.runningPublicId = runningPublicId;
+    this.title = runningPreview.getTitle();
+    this.description = runningPreview.getDescription();
+    this.startAt = runningPreview.getBeginTime();
+    this.participantCount = participantCount;
+    this.createdBy = new HostInfo(userPublicId, name, imgUrl);
+  }
+
+
+
+}

--- a/src/main/java/com/run_us/server/domains/running/run/service/model/RunCreateDto.java
+++ b/src/main/java/com/run_us/server/domains/running/run/service/model/RunCreateDto.java
@@ -1,0 +1,27 @@
+package com.run_us.server.domains.running.run.service.model;
+
+import com.run_us.server.domains.running.run.controller.model.request.SessionAccessLevel;
+import com.run_us.server.domains.running.run.domain.RunPace;
+import lombok.Getter;
+
+import java.time.ZonedDateTime;
+import java.util.List;
+
+@Getter
+public class RunCreateDto {
+  private String title;
+  private String description;
+  private String meetingPoint;
+  private SessionAccessLevel accessLevel;
+  private ZonedDateTime beginTime;
+  private List<RunPace> runPaces;
+
+  public RunCreateDto(String title, String description, String meetingPoint, SessionAccessLevel accessLevel, ZonedDateTime beginTime, List<RunPace> runPaces) {
+    this.title = title;
+    this.description = description;
+    this.meetingPoint = meetingPoint;
+    this.accessLevel = accessLevel;
+    this.beginTime = beginTime;
+    this.runPaces = runPaces;
+  }
+}

--- a/src/main/java/com/run_us/server/domains/running/run/service/usecase/RunCreateUseCase.java
+++ b/src/main/java/com/run_us/server/domains/running/run/service/usecase/RunCreateUseCase.java
@@ -1,12 +1,12 @@
 package com.run_us.server.domains.running.run.service.usecase;
 
-import com.run_us.server.domains.running.run.domain.RunningPreview;
 import com.run_us.server.domains.running.run.service.model.CustomRunCreateResponse;
+import com.run_us.server.domains.running.run.service.model.RunCreateDto;
 import com.run_us.server.domains.running.run.service.model.SessionRunCreateResponse;
 import com.run_us.server.global.common.SuccessResponse;
 
 public interface RunCreateUseCase {
   SuccessResponse<CustomRunCreateResponse> saveNewCustomRun(String userId);
 
-  SuccessResponse<SessionRunCreateResponse> saveNewSessionRun(String userId, RunningPreview runningPreview);
+  SuccessResponse<SessionRunCreateResponse> saveNewSessionRun(String userId, RunCreateDto runningPreview);
 }

--- a/src/main/java/com/run_us/server/domains/running/run/service/usecase/RunPreviewUseCase.java
+++ b/src/main/java/com/run_us/server/domains/running/run/service/usecase/RunPreviewUseCase.java
@@ -1,12 +1,17 @@
 package com.run_us.server.domains.running.run.service.usecase;
 
 import com.run_us.server.domains.running.run.domain.RunningPreview;
+import com.run_us.server.domains.running.run.service.model.JoinedRunPreviewResponse;
 import com.run_us.server.domains.running.run.service.model.GetRunPreviewResponse;
 import com.run_us.server.domains.running.run.service.model.UpdatePreviewResponse;
 import com.run_us.server.global.common.SuccessResponse;
+
+import java.util.List;
 
 public interface RunPreviewUseCase {
   SuccessResponse<UpdatePreviewResponse> updateRunPreview(String userId, Integer runId, RunningPreview preview);
 
   SuccessResponse<GetRunPreviewResponse> getRunPreview(Integer runId);
+
+  SuccessResponse<List<JoinedRunPreviewResponse>> getJoinedRunPreview(String userId, Integer page, Integer size);
 }

--- a/src/main/java/com/run_us/server/domains/running/run/service/usecase/RunPreviewUseCaseImpl.java
+++ b/src/main/java/com/run_us/server/domains/running/run/service/usecase/RunPreviewUseCaseImpl.java
@@ -4,6 +4,7 @@ import com.run_us.server.domains.running.run.controller.model.RunningHttpRespons
 import com.run_us.server.domains.running.run.domain.RunningPreview;
 import com.run_us.server.domains.running.run.service.RunCommandService;
 import com.run_us.server.domains.running.run.service.RunQueryService;
+import com.run_us.server.domains.running.run.service.model.JoinedRunPreviewResponse;
 import com.run_us.server.domains.running.run.service.model.GetRunPreviewResponse;
 import com.run_us.server.domains.running.run.service.model.UpdatePreviewResponse;
 import com.run_us.server.domains.user.domain.User;
@@ -12,6 +13,8 @@ import com.run_us.server.global.common.SuccessResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -35,5 +38,12 @@ public class RunPreviewUseCaseImpl implements RunPreviewUseCase {
   public SuccessResponse<GetRunPreviewResponse> getRunPreview(Integer runId) {
     return SuccessResponse.of(RunningHttpResponseCode.RUN_PREVIEW_FETCHED,
         runQueryService.getRunPreviewById(runId));
+  }
+
+  @Override
+  public SuccessResponse<List<JoinedRunPreviewResponse>> getJoinedRunPreview(String userId, Integer page, Integer size) {
+    User user = userService.getUserByPublicId(userId);
+    return SuccessResponse.of(RunningHttpResponseCode.RUN_PREVIEW_FETCHED,
+        runQueryService.getJoinedRunPreviews(user.getId(), page, size));
   }
 }

--- a/src/main/java/com/run_us/server/domains/running/run/service/usecase/RunPreviewUseCaseImpl.java
+++ b/src/main/java/com/run_us/server/domains/running/run/service/usecase/RunPreviewUseCaseImpl.java
@@ -41,6 +41,7 @@ public class RunPreviewUseCaseImpl implements RunPreviewUseCase {
   }
 
   @Override
+  @Transactional(readOnly = true)
   public SuccessResponse<List<JoinedRunPreviewResponse>> getJoinedRunPreview(String userId, Integer page, Integer size) {
     User user = userService.getUserByPublicId(userId);
     return SuccessResponse.of(RunningHttpResponseCode.RUN_PREVIEW_FETCHED,

--- a/src/test/java/com/run_us/server/domains/running/RunFixtures.java
+++ b/src/test/java/com/run_us/server/domains/running/RunFixtures.java
@@ -2,11 +2,9 @@ package com.run_us.server.domains.running;
 
 import com.run_us.server.domains.running.run.controller.model.request.SessionAccessLevel;
 import com.run_us.server.domains.running.run.domain.Run;
-import com.run_us.server.domains.running.run.domain.RunPace;
 import com.run_us.server.domains.running.run.domain.RunningPreview;
 
 import java.time.ZonedDateTime;
-import java.util.List;
 
 public final class RunFixtures {
 
@@ -21,7 +19,6 @@ public final class RunFixtures {
         .title("title")
         .description("description")
         .meetingPoint("meetingPlace")
-        .paceCategories(List.of(RunPace.PACE_UNDER_500))
         .accessLevel(SessionAccessLevel.ALLOW_ALL)
         .beginTime(ZonedDateTime.now())
         .build();

--- a/src/test/java/com/run_us/server/domains/running/RunRepositoryTest.java
+++ b/src/test/java/com/run_us/server/domains/running/RunRepositoryTest.java
@@ -13,13 +13,16 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.ActiveProfiles;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 @DataJpaTest
+@ActiveProfiles("test")
 public class RunRepositoryTest {
 
   @Autowired
@@ -45,17 +48,14 @@ public class RunRepositoryTest {
   @DisplayName("러닝세션 삭제 시 참가자 정보는 유지")
   void test_delete_run_with_participants() {
     // given
-    saveUsersForParticipants();
+    List<User> users = saveUsersForParticipants();
     Run run = RunFixtures.createRun();
-    runRepository.save(run);
-    Participant participant = ParticipantFixtures.createParticipantWithRunAndUserId(run, 1);
-    Participant participant2 = ParticipantFixtures.createParticipantWithRunAndUserId(run, 2);
-    participantRepository.saveAll(List.of(participant, participant2));
+    runRepository.saveAndFlush(run);
+    List<Participant> participants = addParticipantsToRun(users, run);
     // when
-
     runRepository.delete(run);
     // then
-    assertEquals(2, participantRepository.findByRunId(run.getId()).size());
+    assertEquals(participants.size(), participantRepository.findByRunId(run.getId()).size());
   }
 
   @DisplayName("사용자가 참가한 러닝 세션 조회")
@@ -63,27 +63,30 @@ public class RunRepositoryTest {
   void test_find_joined_run() {
     // given
     List<User> users = saveUsersForParticipants();
-
     Run run = RunFixtures.createRun();
     runRepository.saveAndFlush(run);
-
-    List<Participant> participants = new ArrayList<>();
-    users.stream().map(User::getId).forEach(userId -> {
-      Participant participant = ParticipantFixtures.createParticipantWithRunAndUserId(run, userId);
-      participants.add(participant);
-    });
-    participantRepository.saveAllAndFlush(participants);
-
+    List<Participant> participants = addParticipantsToRun(users, run);
     // when
-    List<JoinedRunPreviewResponse> joinedRuns = runRepository.findJoinedRunPreviews(users.getFirst().getId(), PageRequest.of(0, 10)).getContent();
+    List<JoinedRunPreviewResponse> joinedRuns = runRepository.findJoinedRunPreviews(
+        users.getFirst().getId(),
+        PageRequest.of(0, 10)).getContent();
     // then
     assertEquals(1, joinedRuns.size());
-    assertEquals(joinedRuns.getFirst().getParticipantCount(), 2);
+    assertEquals(joinedRuns.getFirst().getParticipantCount(), participants.size());
   }
 
   private List<User> saveUsersForParticipants() {
     User user = UserFixtures.getDefaultUser();
     User user2 = UserFixtures.getDefaultUser();
     return userRepository.saveAllAndFlush(List.of(user, user2));
+  }
+
+  private List<Participant> addParticipantsToRun(List<User> users, Run run) {
+    List<Participant> participants = new ArrayList<>();
+    users.stream().map(User::getId).forEach(userId -> {
+      Participant participant = ParticipantFixtures.createParticipantWithRunAndUserId(run, userId);
+      participants.add(participant);
+    });
+    return participantRepository.saveAllAndFlush(participants);
   }
 }

--- a/src/test/java/com/run_us/server/domains/running/RunTest.java
+++ b/src/test/java/com/run_us/server/domains/running/RunTest.java
@@ -2,7 +2,6 @@ package com.run_us.server.domains.running;
 
 import com.run_us.server.domains.running.run.controller.model.request.SessionAccessLevel;
 import com.run_us.server.domains.running.run.domain.Run;
-import com.run_us.server.domains.running.run.domain.RunPace;
 import com.run_us.server.domains.running.run.domain.RunStatus;
 import com.run_us.server.domains.running.run.domain.RunningPreview;
 import org.assertj.core.api.Assertions;
@@ -12,7 +11,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
 import java.time.ZonedDateTime;
-import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -42,7 +40,6 @@ class RunTest {
     RunningPreview runningPreview = RunningPreview.builder()
         .title("제목")
         .meetingPoint("평화의문")
-        .paceCategories(List.of(RunPace.PACE_UNDER_500))
         .accessLevel(SessionAccessLevel.ALLOW_ALL)
         .beginTime(now)
         .build();


### PR DESCRIPTION
### 연관된 이슈를 적어주세요 📌
JIS-119 🔥  🚒 

### 작업한 내용을 설명해주세요 ✔️

- 참가한 러닝을 조회하는 API 개발
- JPA이슈로 인한 Pace 위치 조정 : 
```
- Running-Preview-Pace
- Running-Pace
```

### 트러블 슈팅
- ElementCollection이 Embeddable안에 있으면 정말 여러가지 문제가 터지더라구요. 정말 어렵습니다..
- 그래서 Run이 Pace 리스트를 들고있도록 수정했습니다. 좋은방법 or 답 보다는 우선 돌아가게 만들자에 가깝구용
- Preview에서 밖으로 뺐기때문에 기존에 Running을 생성하는 API단이 일부 수정이 불가피했습니다 ㅠ

### 리뷰어에게 하고 싶은 말을 적어주세요
- RunPace를 들고있는 컨테이너의 위치를 수정했습니다
- 조회하는 API가 두번의 쿼리로 분리됐습니다. RunPace는 ElementCollection인데 조인을 한번에 하려니까 에러가 나더라구요.
DTO 프로젝션을 사용하는데 DTO 프로젝션을 할때는 기본적으로 단일 (flat)데이터로 받아야해요. 그래서 여러 태그가 있을 수 있는 저희 상황에서는 프로젝션으로는 해결이 안됐습니다.
- 요런 조회+Aggregation + ... 등은 기능 구현하고 고민해봐요~
### 확인하기

- [x] : 코드에 에러가 없는지 확인했나요?
- [x] : PR에 설명을 기재했나요?
- [x] : PR 태그를 붙였나요?
- [x] : 불필요한 로그나 `System.out`을 제거했나요?