### PR TITLE
[Feat/create-crew-session-run] - 크루용 러닝세션 생성 적용

### DIFF
--- a/src/main/java/com/run_us/server/domains/running/run/controller/model/request/SessionAccessLevel.java
+++ b/src/main/java/com/run_us/server/domains/running/run/controller/model/request/SessionAccessLevel.java
@@ -1,6 +1,0 @@
-package com.run_us.server.domains.running.run.controller.model.request;
-
-public enum SessionAccessLevel {
-  ALLOW_ALL,
-  ONLY_CREW
-}

--- a/src/main/java/com/run_us/server/domains/running/run/controller/model/request/SessionRunCreateRequest.java
+++ b/src/main/java/com/run_us/server/domains/running/run/controller/model/request/SessionRunCreateRequest.java
@@ -3,6 +3,7 @@ package com.run_us.server.domains.running.run.controller.model.request;
 import com.run_us.server.domains.running.common.RunningErrorCode;
 import com.run_us.server.domains.running.common.RunningException;
 import com.run_us.server.domains.running.run.domain.RunPace;
+import com.run_us.server.domains.running.run.domain.SessionAccessLevel;
 import com.run_us.server.domains.running.run.service.model.RunCreateDto;
 import com.run_us.server.global.validator.annotation.EnumValid;
 import lombok.Builder;
@@ -45,7 +46,7 @@ public class SessionRunCreateRequest {
   }
 
   public RunCreateDto toRunCreateDto() {
-    return new RunCreateDto(title, description, meetingPlace, accessLevel, startDateTime, List.copyOf(paceCategories));
+    return new RunCreateDto(title, description, meetingPlace, accessLevel, crewPublicId, startDateTime, List.copyOf(paceCategories));
   }
 
   // 크루 공개일 경우 크루 아이디가 필수

--- a/src/main/java/com/run_us/server/domains/running/run/domain/Run.java
+++ b/src/main/java/com/run_us/server/domains/running/run/domain/Run.java
@@ -26,6 +26,8 @@ public class Run extends CreationTimeAudit {
 
   private String publicId;
 
+  private Integer crewId;
+
   @Enumerated(EnumType.STRING)
   private RunStatus status;
 
@@ -40,6 +42,11 @@ public class Run extends CreationTimeAudit {
   public Run(Integer hostId) {
     this.hostId = hostId;
     this.status = RunStatus.WAITING;
+  }
+
+  public Run (Integer hostId, Integer crewId) {
+    this.hostId = hostId;
+    this.crewId = crewId;
   }
 
   @Override
@@ -62,12 +69,21 @@ public class Run extends CreationTimeAudit {
     return RunStatus.isRunDeletable(this.status);
   }
 
+  public boolean isJoinable() {
+    return RunStatus.isJoinable(this.status);
+  }
+
   public boolean isHost(int userId) {
     return this.hostId.equals(userId);
   }
 
   public void modifyPaceInfo(List<RunPace> runPaces) {
     this.paceCategories = runPaces;
+  }
+
+  public void exposeToCrew(Integer crewPublicId) {
+    validateRunModifiable();
+    this.crewId = crewPublicId;
   }
 
   private void validateRunModifiable() {

--- a/src/main/java/com/run_us/server/domains/running/run/domain/RunningPreview.java
+++ b/src/main/java/com/run_us/server/domains/running/run/domain/RunningPreview.java
@@ -1,6 +1,5 @@
 package com.run_us.server.domains.running.run.domain;
 
-import com.run_us.server.domains.running.run.controller.model.request.SessionAccessLevel;
 import com.run_us.server.domains.running.run.service.model.RunCreateDto;
 import jakarta.persistence.Embeddable;
 import lombok.AccessLevel;
@@ -18,7 +17,7 @@ public class RunningPreview implements Serializable {
   private String title;
   private String description;
   private String meetingPoint;
-  private SessionAccessLevel accessLevel;
+  private SessionAccessLevel accessLevel = SessionAccessLevel.ALLOW_ALL;
   private ZonedDateTime beginTime;
 
   @Builder

--- a/src/main/java/com/run_us/server/domains/running/run/domain/SessionAccessLevel.java
+++ b/src/main/java/com/run_us/server/domains/running/run/domain/SessionAccessLevel.java
@@ -1,0 +1,6 @@
+package com.run_us.server.domains.running.run.domain;
+
+public enum SessionAccessLevel {
+  ALLOW_ALL,
+  ONLY_CREW
+}

--- a/src/main/java/com/run_us/server/domains/running/run/repository/RunRepository.java
+++ b/src/main/java/com/run_us/server/domains/running/run/repository/RunRepository.java
@@ -1,5 +1,6 @@
 package com.run_us.server.domains.running.run.repository;
 
+import com.run_us.server.domains.running.run.domain.SessionAccessLevel;
 import com.run_us.server.domains.running.run.domain.Run;
 import com.run_us.server.domains.running.run.service.model.JoinedRunPreviewResponse;
 import com.run_us.server.domains.running.run.service.model.GetRunPreviewResponse;
@@ -44,4 +45,12 @@ public interface RunRepository extends JpaRepository<Run, Integer> {
           + "WHERE r.publicId IN :keys")
   List<Run> findAllByPublicId(List<String> keys);
 
+  Slice<Run> findAllByCrewId(Integer crewId, PageRequest pageRequest);
+
+  @Query(
+      "SELECT r "
+          + "FROM Run r "
+          + "WHERE r.crewId = :crewId and r.status = :accessLevel"
+  )
+  Slice<Run> findAllByCrewIdAndAccessLevel(Integer crewId, SessionAccessLevel accessLevel, PageRequest pageRequest);
 }

--- a/src/main/java/com/run_us/server/domains/running/run/service/RunCommandService.java
+++ b/src/main/java/com/run_us/server/domains/running/run/service/RunCommandService.java
@@ -30,6 +30,15 @@ public class RunCommandService {
     return runRepository.save(run);
   }
 
+  // TODO: 중복 코드
+  public Run saveNewCrewRun(User user, Integer crewId, RunCreateDto createDto) {
+    Run run = new Run(user.getId(), crewId);
+    RunningPreview preview = RunningPreview.from(createDto);
+    run.modifySessionInfo(preview);
+    run.modifyPaceInfo(createDto.getRunPaces());
+    return runRepository.save(run);
+  }
+
   public void updateRunPreview(Integer userId, Integer runId, RunningPreview preview) {
     Run run = runQueryService.findByRunId(runId);
     runValidator.validateIsRunOwner(userId, run);

--- a/src/main/java/com/run_us/server/domains/running/run/service/RunQueryService.java
+++ b/src/main/java/com/run_us/server/domains/running/run/service/RunQueryService.java
@@ -3,11 +3,13 @@ package com.run_us.server.domains.running.run.service;
 import com.run_us.server.domains.running.common.RunningErrorCode;
 import com.run_us.server.domains.running.common.RunningException;
 import com.run_us.server.domains.running.run.domain.Run;
+import com.run_us.server.domains.running.run.domain.SessionAccessLevel;
 import com.run_us.server.domains.running.run.repository.RunRepository;
 import com.run_us.server.domains.running.run.service.model.JoinedRunPreviewResponse;
 import com.run_us.server.domains.running.run.service.model.GetRunPreviewResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
@@ -31,6 +33,16 @@ public class RunQueryService {
     return runRepository
         .findByPublicId(runPublicId)
         .orElseThrow(() -> RunningException.of(RunningErrorCode.RUNNING_NOT_FOUND));
+  }
+
+  public Slice<Run> findAllByCrewId(Integer crewId, Integer page, Integer size) {
+    PageRequest pageRequest = PageRequest.of(page, size);
+    return runRepository.findAllByCrewId(crewId, pageRequest);
+  }
+
+  public Slice<Run> findAllByCrewIdAndAccessLevel(Integer crewId, SessionAccessLevel accessLevel, Integer page, Integer size) {
+    PageRequest pageRequest = PageRequest.of(page, size);
+    return runRepository.findAllByCrewIdAndAccessLevel(crewId, accessLevel, pageRequest);
   }
 
   public GetRunPreviewResponse getRunPreviewById(Integer runId) {

--- a/src/main/java/com/run_us/server/domains/running/run/service/RunValidator.java
+++ b/src/main/java/com/run_us/server/domains/running/run/service/RunValidator.java
@@ -2,7 +2,9 @@ package com.run_us.server.domains.running.run.service;
 
 import com.run_us.server.domains.running.common.RunningErrorCode;
 import com.run_us.server.domains.running.common.RunningException;
+import com.run_us.server.domains.running.run.domain.SessionAccessLevel;
 import com.run_us.server.domains.running.run.domain.Run;
+import com.run_us.server.domains.running.run.service.model.RunCreateDto;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -25,5 +27,14 @@ public final class RunValidator {
     if (!run.isJoinable()) {
       throw RunningException.of(RunningErrorCode.RUNNING_NOT_JOINABLE);
     }
+  }
+
+  public boolean isCrewRunCreateCommand(RunCreateDto createDto) {
+    // ONLY_CREW인데 CREW ID가 없는 경우
+    if(createDto.getAccessLevel() == SessionAccessLevel.ONLY_CREW && createDto.getCrewPublicId() != null) {
+      throw RunningException.of(RunningErrorCode.RUNNING_SESSION_INVALID);
+    }
+    // ONLY_CREW + CREW ID or PUBLIC + CREW ID
+    return createDto.getAccessLevel() == SessionAccessLevel.ONLY_CREW || createDto.getCrewPublicId() != null;
   }
 }

--- a/src/main/java/com/run_us/server/domains/running/run/service/model/RunCreateDto.java
+++ b/src/main/java/com/run_us/server/domains/running/run/service/model/RunCreateDto.java
@@ -1,6 +1,6 @@
 package com.run_us.server.domains.running.run.service.model;
 
-import com.run_us.server.domains.running.run.controller.model.request.SessionAccessLevel;
+import com.run_us.server.domains.running.run.domain.SessionAccessLevel;
 import com.run_us.server.domains.running.run.domain.RunPace;
 import lombok.Getter;
 
@@ -13,14 +13,16 @@ public class RunCreateDto {
   private String description;
   private String meetingPoint;
   private SessionAccessLevel accessLevel;
+  private String crewPublicId;
   private ZonedDateTime beginTime;
   private List<RunPace> runPaces;
 
-  public RunCreateDto(String title, String description, String meetingPoint, SessionAccessLevel accessLevel, ZonedDateTime beginTime, List<RunPace> runPaces) {
+  public RunCreateDto(String title, String description, String meetingPoint, SessionAccessLevel accessLevel, String crewPublicId, ZonedDateTime beginTime, List<RunPace> runPaces) {
     this.title = title;
     this.description = description;
     this.meetingPoint = meetingPoint;
     this.accessLevel = accessLevel;
+    this.crewPublicId = crewPublicId;
     this.beginTime = beginTime;
     this.runPaces = runPaces;
   }

--- a/src/main/java/com/run_us/server/domains/running/run/service/usecase/RunCreateUseCaseImpl.java
+++ b/src/main/java/com/run_us/server/domains/running/run/service/usecase/RunCreateUseCaseImpl.java
@@ -1,10 +1,13 @@
 package com.run_us.server.domains.running.run.service.usecase;
 
+import com.run_us.server.domains.crew.domain.Crew;
+import com.run_us.server.domains.crew.service.CrewService;
 import com.run_us.server.domains.running.common.PassCodeRegistry;
 import com.run_us.server.domains.running.run.controller.model.RunningHttpResponseCode;
 import com.run_us.server.domains.running.run.domain.Run;
 import com.run_us.server.domains.running.run.service.ParticipantService;
 import com.run_us.server.domains.running.run.service.RunCommandService;
+import com.run_us.server.domains.running.run.service.RunValidator;
 import com.run_us.server.domains.running.run.service.model.CustomRunCreateResponse;
 import com.run_us.server.domains.running.run.service.model.RunCreateDto;
 import com.run_us.server.domains.running.run.service.model.SessionRunCreateResponse;
@@ -23,6 +26,8 @@ public class RunCreateUseCaseImpl implements RunCreateUseCase {
   private final ParticipantService participantService;
   private final UserService userService;
   private final PassCodeRegistry passCodeRegistry;
+  private final CrewService crewService;
+  private final RunValidator runValidator;
 
   // Custom Run은 생성하면서 바로 Passcode를 생성하여 반환한다.
   @Override
@@ -38,8 +43,17 @@ public class RunCreateUseCaseImpl implements RunCreateUseCase {
   @Transactional
   public SuccessResponse<SessionRunCreateResponse> saveNewSessionRun(String userId, RunCreateDto runCreateDto) {
     User user = userService.getUserByPublicId(userId);
-    Run run = runCommandService.saveNewRun(user, runCreateDto);
-    participantService.registerParticipant(user.getId(), run);
-    return SuccessResponse.of(RunningHttpResponseCode.SESSION_RUN_CREATED,SessionRunCreateResponse.from(run));
+    Run savedRun = createCrewRunOrDefault(user, runCreateDto);
+    participantService.registerParticipant(user.getId(), savedRun);
+    return SuccessResponse.of(RunningHttpResponseCode.SESSION_RUN_CREATED,SessionRunCreateResponse.from(savedRun));
+  }
+
+  // ONLY_CREW인 경우에는 Crew를 찾아서 Run을 생성한다. 그렇지 않은 경우에는 일반 Run을 생성한다.
+  private Run createCrewRunOrDefault(User user, RunCreateDto runCreateDto) {
+    if (runValidator.isCrewRunCreateCommand(runCreateDto)) {
+      Crew crew = crewService.getCrewByPublicId(runCreateDto.getCrewPublicId());
+      return runCommandService.saveNewCrewRun(user, crew.getId(), runCreateDto);
+    }
+    return runCommandService.saveNewRun(user, runCreateDto);
   }
 }

--- a/src/test/java/com/run_us/server/domains/running/RunFixtures.java
+++ b/src/test/java/com/run_us/server/domains/running/RunFixtures.java
@@ -1,6 +1,6 @@
 package com.run_us.server.domains.running;
 
-import com.run_us.server.domains.running.run.controller.model.request.SessionAccessLevel;
+import com.run_us.server.domains.running.run.domain.SessionAccessLevel;
 import com.run_us.server.domains.running.run.domain.Run;
 import com.run_us.server.domains.running.run.domain.RunningPreview;
 
@@ -9,8 +9,14 @@ import java.time.ZonedDateTime;
 public final class RunFixtures {
 
   public static Run createRun() {
-    Run run = new Run(1);
+    Run run = new Run(null);
     run.modifySessionInfo(createRunningPreview());
+    return run;
+  }
+
+  public static Run createRunWithCrewIdAndAccessLevel(Integer crewId, SessionAccessLevel accessLevel) {
+    Run run = new Run(null, crewId);
+    run.modifySessionInfo(createRunningPreviewWithAccessLevel(accessLevel));
     return run;
   }
 
@@ -20,6 +26,16 @@ public final class RunFixtures {
         .description("description")
         .meetingPoint("meetingPlace")
         .accessLevel(SessionAccessLevel.ALLOW_ALL)
+        .beginTime(ZonedDateTime.now())
+        .build();
+  }
+
+  private static RunningPreview createRunningPreviewWithAccessLevel(SessionAccessLevel accessLevel) {
+    return RunningPreview.builder()
+        .title("title")
+        .description("description")
+        .meetingPoint("meetingPlace")
+        .accessLevel(accessLevel)
         .beginTime(ZonedDateTime.now())
         .build();
   }

--- a/src/test/java/com/run_us/server/domains/running/RunTest.java
+++ b/src/test/java/com/run_us/server/domains/running/RunTest.java
@@ -1,6 +1,6 @@
 package com.run_us.server.domains.running;
 
-import com.run_us.server.domains.running.run.controller.model.request.SessionAccessLevel;
+import com.run_us.server.domains.running.run.domain.SessionAccessLevel;
 import com.run_us.server.domains.running.run.domain.Run;
 import com.run_us.server.domains.running.run.domain.RunStatus;
 import com.run_us.server.domains.running.run.domain.RunningPreview;


### PR DESCRIPTION
### 연관된 이슈를 적어주세요 📌
JIS-97

### 작업한 내용을 설명해주세요 ✔️

- 러닝 생성시 크루ID를 전달하면 크루 세션으로 생성하는 코드 추가
- is/else로 static하게 분기처리
- 크루화면에서 사용할 러닝 조회 함수 작성
  - `findByCrewId`
  - `findByCrewIdAndAccessLevel` 

### 트러블 슈팅

### 리뷰어에게 하고 싶은 말을 적어주세요
- 정기런 여부가 아직 없더라구요 빠른 시일내에 추가하겠습니다.
- 테스트는 db 테스트를 위해 정말 가능한지 확인하는 여부로 작성했습니다. 

### 확인하기

- [x] : 코드에 에러가 없는지 확인했나요?
- [x] : PR에 설명을 기재했나요?
- [x] : PR 태그를 붙였나요?
- [x] : 불필요한 로그나 `System.out`을 제거했나요?