### PR TITLE
[Fix/crew-domain] - CrewJoinRequest 수정

### DIFF
--- a/src/main/java/com/run_us/server/domains/crew/controller/model/enums/CrewErrorCode.java
+++ b/src/main/java/com/run_us/server/domains/crew/controller/model/enums/CrewErrorCode.java
@@ -14,6 +14,8 @@ public enum CrewErrorCode implements CustomResponseCode {
     DUPLICATE_JOIN_REQUEST("CEH4003", "Duplicate join request", "Duplicate join request", HttpStatus.BAD_REQUEST),
     SUSPENDED_CREW("CEH4004", "Suspended crew", "Suspended crew", HttpStatus.BAD_REQUEST),
     INVALID_JOIN_REQUEST_STATUS("CEH4005", "Invalid join request status", "Invalid join request status", HttpStatus.BAD_REQUEST),
+    JOIN_REQUEST_ALREADY_PROCESSED("CEH4006", "Join request already processed", "Join request already processed", HttpStatus.BAD_REQUEST),
+
 
     // 403
     RECENTLY_REJECTED_REQUEST("CEH4032","Recently rejected request","Recently rejected request",HttpStatus.FORBIDDEN)

--- a/src/main/java/com/run_us/server/domains/crew/domain/Crew.java
+++ b/src/main/java/com/run_us/server/domains/crew/domain/Crew.java
@@ -47,10 +47,6 @@ public class Crew extends DateAudit {
     private CrewDescription crewDescription;
 
     @ElementCollection
-    @CollectionTable(name = "crew_join_requests", joinColumns = @JoinColumn(name="crew_id"))
-    private List<CrewJoinRequest> joinRequests = new ArrayList<>();
-
-    @ElementCollection
     @CollectionTable(name = "crew_memberships", joinColumns = @JoinColumn(name="crew_id"))
     private List<CrewMembership> crewMemberships = new ArrayList<>();
 
@@ -66,31 +62,12 @@ public class Crew extends DateAudit {
         return this.status == CrewStatus.ACTIVE;
     }
 
-    public void addJoinRequest(CrewJoinRequest joinRequest) {
-        this.joinRequests.add(joinRequest);
-    }
-
-    public void cancelJoinRequest(CrewJoinRequest joinRequest) {
-        joinRequests.stream()
-                .filter(request -> request.getUserId().equals(joinRequest.getUserId()))
-                .filter(request -> request.getStatus() == CrewJoinRequestStatus.WAITING)
-                .findFirst()
-                .ifPresent(CrewJoinRequest::cancel);
-    }
-
     public void addMember(Integer userId) {
         this.crewMemberships.add(CrewMembership.builder()
             .userId(userId)
             .build()
         );
         this.memberCount++;
-    }
-
-    public void reviewJoinRequest(CrewJoinRequest joinRequest, CrewJoinRequestStatus status) {
-        joinRequests.stream()
-                .filter(request -> request.getId().equals(joinRequest.getId()))
-                .findFirst()
-                .ifPresent(request -> request.review(owner, status));
     }
 
     @Override

--- a/src/main/java/com/run_us/server/domains/crew/domain/CrewMembership.java
+++ b/src/main/java/com/run_us/server/domains/crew/domain/CrewMembership.java
@@ -16,7 +16,6 @@ import static com.run_us.server.global.common.GlobalConst.TIME_ZONE_ID;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "crew_memberships")
-@SQLRestriction("deleted_at is null")
 @Embeddable
 public class CrewMembership {
 

--- a/src/main/java/com/run_us/server/domains/crew/repository/CrewJoinRequestRepository.java
+++ b/src/main/java/com/run_us/server/domains/crew/repository/CrewJoinRequestRepository.java
@@ -1,0 +1,28 @@
+package com.run_us.server.domains.crew.repository;
+
+import com.run_us.server.domains.crew.domain.CrewJoinRequest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.time.ZonedDateTime;
+import java.util.Optional;
+
+public interface CrewJoinRequestRepository extends JpaRepository<CrewJoinRequest, Integer> {
+
+  Optional<CrewJoinRequest> findById(Integer id);
+
+  Slice<CrewJoinRequest> findAllByCrewId(Integer crewId, PageRequest pageRequest);
+
+  Optional<CrewJoinRequest> findByCrewIdAndUserId(Integer crewId, Integer userId);
+
+  @Query("SELECT jr from CrewJoinRequest jr "
+      + "WHERE jr.crewId = :crewId AND jr.userId = :userId "
+      + "AND jr.requestedAt > :recentDate")
+  Optional<CrewJoinRequest> findByCrewIdAndUserIdAndAfterRequestedAt(
+      Integer crewId,
+      Integer userId,
+      ZonedDateTime recentDate
+  );
+}

--- a/src/main/java/com/run_us/server/domains/crew/repository/CrewRepository.java
+++ b/src/main/java/com/run_us/server/domains/crew/repository/CrewRepository.java
@@ -14,62 +14,7 @@ import java.util.Optional;
 public interface CrewRepository extends JpaRepository<Crew, Integer> {
     Optional<Crew> findByPublicId(String publicId);
 
-    @Query("SELECT jr FROM Crew c " +
-            "JOIN c.joinRequests jr " +
-            "WHERE c.publicId = :publicId " +
-            "AND jr.userId = :userInternalId " +
-            "AND jr.status = 'WAITING'")
-    Optional<CrewJoinRequest> findWaitingJoinRequest(
-            @Param("crewId") String publicId,
-            @Param("userId") Integer userInternalId
-    );
-
     @Query("SELECT EXISTS (SELECT 1 FROM Crew c JOIN c.crewMemberships m " +
             "WHERE c.id = :crewId AND m.userId = :userId)")
     boolean existsMembershipByCrewIdAndUserId(Integer crewId, Integer userId);
-
-    @Query("SELECT EXISTS (SELECT 1 FROM Crew c JOIN c.joinRequests r " +
-            "WHERE c.id = :crewId AND r.userId = :userId " +
-            "AND r.status = 'WAITING')")
-    boolean existsWaitingRequestByCrewIdAndUserId(Integer crewId, Integer userId);
-
-    @Query("SELECT EXISTS (SELECT 1 FROM Crew c JOIN c.joinRequests r " +
-            "WHERE c.id = :crewId AND r.userId = :userId " +
-            "AND r.status = 'REJECTED' " +
-            "AND r.processedAt > :recentDate)")
-    boolean existsRecentRejectedRequestByCrewIdAndUserId(
-            Integer crewId,
-            Integer userId,
-            LocalDateTime recentDate
-    );
-
-    @Query("SELECT jr FROM Crew c " +
-            "JOIN c.joinRequests jr " +
-            "WHERE c.publicId = :publicId " +
-            "AND jr.status = 'WAITING' " +
-            "ORDER BY jr.requestedAt DESC")
-    List<CrewJoinRequest> findJoinRequestsByCrew(
-            @Param("crewId") String publicId,
-            PageRequest pageRequest
-    );
-
-    @Query("SELECT COUNT(jr) > 0 FROM Crew c " +
-            "JOIN c.joinRequests jr " +
-            "WHERE c.id = :crewId " +
-            "AND jr.id = :requestId " +
-            "AND jr.status = 'WAITING'")
-    boolean existsWaitingJoinRequest(
-            @Param("crewId") Integer crewId,
-            @Param("requestId") Integer requestId
-    );
-
-    @Query("SELECT jr FROM Crew c " +
-            "JOIN c.joinRequests jr " +
-            "WHERE c.id = :crewId " +
-            "AND jr.id = :requestId " +
-            "AND jr.status = 'WAITING'")
-    Optional<CrewJoinRequest> findWaitingJoinRequest(
-            @Param("crewId") Integer crewId,
-            @Param("requestId") Integer requestId
-    );
 }

--- a/src/main/java/com/run_us/server/domains/crew/service/CrewService.java
+++ b/src/main/java/com/run_us/server/domains/crew/service/CrewService.java
@@ -6,6 +6,7 @@ import com.run_us.server.domains.crew.domain.Crew;
 import com.run_us.server.domains.crew.domain.CrewJoinRequest;
 import com.run_us.server.domains.crew.domain.enums.CrewJoinRequestStatus;
 import com.run_us.server.domains.crew.domain.enums.CrewJoinType;
+import com.run_us.server.domains.crew.repository.CrewJoinRequestRepository;
 import com.run_us.server.domains.crew.repository.CrewRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -21,6 +22,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class CrewService {
     private final CrewRepository crewRepository;
+    private final CrewJoinRequestRepository crewJoinRequestRepository;
 
     public Crew getCrewByPublicId(String crewPublicId) {
         log.debug("action=fetch_crew crewPublicId={}", crewPublicId);
@@ -31,41 +33,31 @@ public class CrewService {
     @Transactional(readOnly = true)
     public List<CrewJoinRequest> getJoinRequests(Crew crew, PageRequest pageRequest) {
         log.debug("action=get_join_requests_start crewId={}", crew.getPublicId());
-        return crewRepository.findJoinRequestsByCrew(crew.getPublicId(), pageRequest);
+        return crewJoinRequestRepository.findAllByCrewId(crew.getId(), pageRequest).getContent();
     }
 
     @Transactional
     public CrewJoinRequest createJoinRequest(Crew crew, Integer userInternalId, String answer) {
         log.debug("action=create_join_request crewPublicId={} userInternalId={}", crew.getPublicId(), userInternalId);
 
-        CrewJoinRequest joinRequest = CrewJoinRequest.from(userInternalId, answer);
+        CrewJoinRequest joinRequest = CrewJoinRequest.from(userInternalId, crew.getId(), answer);
 
         if (crew.getJoinType() == CrewJoinType.OPEN) {
             log.debug("action=auto_approve_join_request crewPublicId={} userInternalId={}", crew.getPublicId(), userInternalId);
-            joinRequest.review(crew.getOwner(), CrewJoinRequestStatus.APPROVED);
+            joinRequest.review(crew.getOwner().getId(), CrewJoinRequestStatus.APPROVED);
             crew.addMember(userInternalId);
         }
-
-        crew.addJoinRequest(joinRequest);
-        crewRepository.save(crew);
-
         log.debug("action=create_join_request_complete crewPublicId={} userInternalId={} status={}",
                 crew.getPublicId(), userInternalId, joinRequest.getStatus());
-
         return joinRequest;
     }
 
     @Transactional
     public void cancelJoinRequest(Crew crew, Integer userInternalId) {
         log.debug("action=cancel_join_request crewPublicId={} userInternalId={}", crew.getPublicId(), userInternalId);
-
-
-        CrewJoinRequest joinRequest = crewRepository.findWaitingJoinRequest(crew.getPublicId(), userInternalId)
+        CrewJoinRequest joinRequest = crewJoinRequestRepository.findByCrewIdAndUserId(crew.getId(), userInternalId)
                 .orElseThrow(() -> new CrewException(CrewErrorCode.JOIN_REQUEST_NOT_FOUND));
-
-        crew.cancelJoinRequest(joinRequest);
-        crewRepository.save(crew);
-
+        joinRequest.cancel();
         log.debug("action=cancel_join_request_complete crewPublicId={} userInternalId={}", crew.getPublicId(), userInternalId);
     }
 
@@ -74,16 +66,13 @@ public class CrewService {
         log.debug("action=review_join_request crewPublicId={} requestId={} status={} userInternalId={}",
                 crew.getPublicId(), requestId, status, userInternalId);
 
-        CrewJoinRequest request = crewRepository.findWaitingJoinRequest(crew.getId(), requestId)
+        CrewJoinRequest request = crewJoinRequestRepository.findById(requestId)
                 .orElseThrow(() -> new CrewException(CrewErrorCode.JOIN_REQUEST_NOT_FOUND));
 
-        crew.reviewJoinRequest(request, status);
-
+        request.review(userInternalId, status);
         if(status == CrewJoinRequestStatus.APPROVED) {
             crew.addMember(request.getUserId());
         }
-        crewRepository.save(crew);
-
         log.debug("action=process_join_request_usecase_complete crewPublicId={} requestId={}",
                 crew.getPublicId(), requestId);
         return request;

--- a/src/main/java/com/run_us/server/domains/crew/service/CrewValidator.java
+++ b/src/main/java/com/run_us/server/domains/crew/service/CrewValidator.java
@@ -4,37 +4,44 @@ import com.run_us.server.domains.crew.domain.Crew;
 import com.run_us.server.domains.crew.controller.model.enums.CrewException;
 import com.run_us.server.domains.crew.controller.model.enums.CrewErrorCode;
 
+import com.run_us.server.domains.crew.domain.CrewJoinRequest;
 import com.run_us.server.domains.crew.domain.enums.CrewJoinRequestStatus;
+import com.run_us.server.domains.crew.repository.CrewJoinRequestRepository;
 import com.run_us.server.domains.crew.repository.CrewRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 import java.util.EnumSet;
+
+import static com.run_us.server.global.common.GlobalConst.ZONE_ID;
 
 @Component
 @RequiredArgsConstructor
 public class CrewValidator {
     private final CrewRepository crewRepository;
+    private final CrewJoinRequestRepository crewJoinRequestRepository;
     private static final int REJECT_LOCK_PERIOD_MONTHS = 1;
 
     public void validateCanJoinCrew(Integer userId, Crew crew) {
+        if (!crew.isActive()) {
+            throw new CrewException(CrewErrorCode.SUSPENDED_CREW);
+        }
         if (crewRepository.existsMembershipByCrewIdAndUserId(crew.getId(), userId)) {
             throw new CrewException(CrewErrorCode.ALREADY_CREW_MEMBER);
         }
+        LocalDateTime oneMonthAgo = LocalDateTime.now().minusMonths(REJECT_LOCK_PERIOD_MONTHS);
+        CrewJoinRequest joinRequestWithinMonth = crewJoinRequestRepository.
+            findByCrewIdAndUserIdAndAfterRequestedAt(crew.getId(), userId, ZonedDateTime.of(oneMonthAgo, ZONE_ID)).orElse(null);
 
-        if (crewRepository.existsWaitingRequestByCrewIdAndUserId(crew.getId(), userId)) {
+        if(joinRequestWithinMonth == null) return;
+
+        if(joinRequestWithinMonth.getStatus() == CrewJoinRequestStatus.WAITING) {
             throw new CrewException(CrewErrorCode.DUPLICATE_JOIN_REQUEST);
         }
-
-        LocalDateTime oneMonthAgo = LocalDateTime.now().minusMonths(REJECT_LOCK_PERIOD_MONTHS);
-        if (crewRepository.existsRecentRejectedRequestByCrewIdAndUserId(
-                crew.getId(), userId, oneMonthAgo)) {
+        if(joinRequestWithinMonth.getStatus() == CrewJoinRequestStatus.REJECTED) {
             throw new CrewException(CrewErrorCode.RECENTLY_REJECTED_REQUEST);
-        }
-
-        if (!crew.isActive()) {
-            throw new CrewException(CrewErrorCode.SUSPENDED_CREW);
         }
     }
 
@@ -48,16 +55,12 @@ public class CrewValidator {
         }
     }
 
-    public void validateCanReviewJoinRequest(Integer userId, Integer requestId, CrewJoinRequestStatus status, Crew crew) {
+    public void validateCanReviewJoinRequest(Integer userId, CrewJoinRequestStatus status, Crew crew) {
         if(!crew.getOwner().getId().equals(userId)) {
             throw new CrewException(CrewErrorCode.CREW_NOT_FOUND);
         }
 
-        if(!crewRepository.existsWaitingJoinRequest(crew.getId(), requestId)) {
-            throw new CrewException(CrewErrorCode.JOIN_REQUEST_NOT_FOUND);
-        }
-
-        if(!EnumSet.of(CrewJoinRequestStatus.APPROVED, CrewJoinRequestStatus.REJECTED).contains(status)) {
+        if(EnumSet.of(CrewJoinRequestStatus.APPROVED, CrewJoinRequestStatus.REJECTED).contains(status)) {
             throw new CrewException(CrewErrorCode.INVALID_JOIN_REQUEST_STATUS);
         }
 

--- a/src/main/java/com/run_us/server/domains/crew/service/usecase/CrewJoinUseCaseImpl.java
+++ b/src/main/java/com/run_us/server/domains/crew/service/usecase/CrewJoinUseCaseImpl.java
@@ -95,7 +95,7 @@ public class CrewJoinUseCaseImpl implements CrewJoinUseCase {
                 crewPublicId, requestId, status);
 
         Crew crew = crewService.getCrewByPublicId(crewPublicId);
-        crewValidator.validateCanReviewJoinRequest(userInternalId, requestId, status, crew);
+        crewValidator.validateCanReviewJoinRequest(userInternalId, status, crew);
 
         CrewJoinRequest joinRequest = crewService.reviewJoinRequest(
                 crew,

--- a/src/test/java/com/run_us/server/domains/crew/domain/CrewFixtures.java
+++ b/src/test/java/com/run_us/server/domains/crew/domain/CrewFixtures.java
@@ -12,17 +12,25 @@ public final class CrewFixtures {
 
     /**
      * 크루장이 크루를 처음 개설했을 때의 Crew 엔티티 반환
-     * @return
+     * @return Crew 엔티티
      */
     public static Crew createInitalCrew(String ownerNickname, String crewTitle, String crewIntro) {
         User owner = UserFixtures.getDefaultUserWithNickname(ownerNickname);
-        Crew crew = Crew.builder()
-                .owner(owner)
-                .crewDescription(createCrewDescription(crewTitle, crewIntro))
-                .crewMemberships(createOwnerOnlyCrewMemberships(owner))
-                .joinType(CrewJoinType.OPEN)
-                .build();
-        return crew;
+      return Crew.builder()
+              .owner(owner)
+              .crewDescription(createCrewDescription(crewTitle, crewIntro))
+              .crewMemberships(createOwnerOnlyCrewMemberships(owner))
+              .joinType(CrewJoinType.OPEN)
+              .build();
+    }
+
+    public static Crew createCrewWithOwner(User owner, String crewTitle, String crewIntro) {
+      return Crew.builder()
+              .owner(owner)
+              .crewDescription(createCrewDescription(crewTitle, crewIntro))
+              .crewMemberships(createOwnerOnlyCrewMemberships(owner))
+              .joinType(CrewJoinType.OPEN)
+              .build();
     }
 
     private static CrewDescription createCrewDescription(String crewTitle, String crewIntro) {
@@ -39,8 +47,8 @@ public final class CrewFixtures {
 
     /**
      * 크루장만 포함된 회원 목록 반환
-     * @param user
-     * @return
+     * @param user 크루장
+     * @return 크루장만 포함된 크루 멤버십 목록
      */
     private static List<CrewMembership> createOwnerOnlyCrewMemberships(User user) {
         CrewMembership ownerMembership = CrewMembership.builder()

--- a/src/test/java/com/run_us/server/domains/crew/domain/CrewJoinRequestRepositoryTest.java
+++ b/src/test/java/com/run_us/server/domains/crew/domain/CrewJoinRequestRepositoryTest.java
@@ -1,0 +1,82 @@
+package com.run_us.server.domains.crew.domain;
+
+import com.run_us.server.domains.crew.domain.enums.CrewJoinRequestStatus;
+import com.run_us.server.domains.crew.repository.CrewJoinRequestRepository;
+import com.run_us.server.domains.crew.repository.CrewRepository;
+import com.run_us.server.domains.user.domain.User;
+import com.run_us.server.domains.user.domain.UserFixtures;
+import com.run_us.server.domains.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.time.ZonedDateTime;
+
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@DataJpaTest
+public class CrewJoinRequestRepositoryTest {
+
+  @Autowired
+  private CrewJoinRequestRepository crewJoinRequestRepository;
+  @Autowired
+  private CrewRepository crewRepository;
+  @Autowired
+  private UserRepository userRepository;
+
+  @DisplayName("크루 가입 요청 생성 테스트")
+  @Test
+  void test_create_join_request() {
+    // given
+    User user = UserFixtures.getDefaultUser();
+    userRepository.saveAndFlush(user);
+    Crew crew = CrewFixtures.createCrewWithOwner(user, "빵빵런", "러닝하고 빵먹고");
+    crewRepository.saveAndFlush(crew);
+    Integer userInternalId = 1;
+    String answer = "달리기 좋아요";
+
+    // when
+    CrewJoinRequest joinRequest = crewJoinRequestRepository.saveAndFlush(CrewJoinRequest.from(userInternalId, crew.getId(), answer));
+
+    // then
+    CrewJoinRequest savedRequest = crewJoinRequestRepository.findByCrewIdAndUserId(crew.getId(), userInternalId).orElse(null);
+    assertNotNull(savedRequest);
+    assertEquals(joinRequest.getCrewId(), crew.getId());
+    assertEquals(joinRequest.getUserId(), userInternalId);
+    assertEquals(joinRequest.getAnswer(), answer);
+  }
+
+  @DisplayName("1달 이내 크루 가입 요청 조회 테스트")
+  @Test
+  void test_find_join_request_within_month() {
+    // given
+    User user = UserFixtures.getDefaultUser();
+    userRepository.saveAndFlush(user);
+    Crew crew = CrewFixtures.createCrewWithOwner(user, "빵빵런", "러닝하고 빵먹고");
+    crewRepository.saveAndFlush(crew);
+    Integer userInternalId = 1;
+    String answer = "달리기 좋아요";
+
+    CrewJoinRequest joinRequestBeforeDays = CrewJoinRequest.builder()
+        .crewId(crew.getId())
+        .userId(userInternalId)
+        .answer(answer)
+        .requestedAt(ZonedDateTime.now().minusWeeks(1))
+        .processedAt(ZonedDateTime.now().minusDays(1))
+        .status(CrewJoinRequestStatus.WAITING)
+        .build();
+    crewJoinRequestRepository.saveAndFlush(joinRequestBeforeDays);
+
+    // when
+    ZonedDateTime monthAgo = ZonedDateTime.now().minusMonths(1);
+    CrewJoinRequest joinRequests = crewJoinRequestRepository.findByCrewIdAndUserIdAndAfterRequestedAt(crew.getId(), userInternalId, monthAgo).orElse(null);
+
+    // then
+    assertNotNull(joinRequests);
+  }
+
+
+}

--- a/src/test/java/com/run_us/server/domains/crew/service/CrewValidatorTest.java
+++ b/src/test/java/com/run_us/server/domains/crew/service/CrewValidatorTest.java
@@ -1,0 +1,66 @@
+package com.run_us.server.domains.crew.service;
+
+import com.run_us.server.domains.crew.controller.model.enums.CrewException;
+import com.run_us.server.domains.crew.domain.Crew;
+import com.run_us.server.domains.crew.domain.CrewFixtures;
+import com.run_us.server.domains.crew.domain.CrewJoinRequest;
+import com.run_us.server.domains.crew.domain.enums.CrewJoinRequestStatus;
+import com.run_us.server.domains.crew.repository.CrewJoinRequestRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import java.time.ZonedDateTime;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@SpringBootTest
+class CrewValidatorTest {
+
+  @MockBean
+  private CrewJoinRequestRepository crewJoinRequestRepository;
+
+  @Autowired
+  private CrewValidator crewValidator;
+
+  @DisplayName("한달 이내에 제출한 가입신청이 아직 처리되지 않은 경우 에러 반환")
+  @Test
+  void should_fail_when_request_within_one_month_not_reviewed() {
+    // given
+    int userId = 1;
+    Crew crew = CrewFixtures.createInitalCrew("owner", "title", "intro");
+    when(crewJoinRequestRepository.findByCrewIdAndUserIdAndAfterRequestedAt(any(), any(), any())).thenReturn(
+        Optional.ofNullable(CrewJoinRequest.builder()
+            .crewId(crew.getId())
+            .userId(userId)
+            .status(CrewJoinRequestStatus.WAITING)
+            .requestedAt(ZonedDateTime.now().minusMonths(1))
+            .processedAt(null)
+            .build())
+    );
+    assertThrows(CrewException.class, () -> crewValidator.validateCanJoinCrew(userId, crew));
+  }
+
+  @DisplayName("한달 이내에 제출한 가입신청이 거절된 경우 에러 반환")
+  @Test
+  void should_fail_when_request_within_one_month_rejected() {
+    // given
+    int userId = 1;
+    Crew crew = CrewFixtures.createInitalCrew("owner", "title", "intro");
+    when(crewJoinRequestRepository.findByCrewIdAndUserIdAndAfterRequestedAt(any(), any(), any())).thenReturn(
+        Optional.ofNullable(CrewJoinRequest.builder()
+            .crewId(crew.getId())
+            .userId(userId)
+            .status(CrewJoinRequestStatus.REJECTED)
+            .requestedAt(ZonedDateTime.now().minusMonths(1))
+            .processedAt(ZonedDateTime.now())
+            .build())
+    );
+    assertThrows(CrewException.class, () -> crewValidator.validateCanJoinCrew(userId, crew));
+  }
+}


### PR DESCRIPTION
### 연관된 이슈를 적어주세요 📌
CI-fail 이슈, JPA

### 작업한 내용을 설명해주세요 ✔️

- JPA 에러로 실패하던 ci 원인 해결
  - `CrewJoinRequest` 는 엔티티로, 다른 엔티티들과는 연관관계를 맺지 않고 id를 통한 간접 참조
  - JPQL 에러 해결, 불필요한 쿼리문 제거, Repository 분리
- `CrewValidator` 로직 일부 수정
  - 여러번 쿼리 수행을 통해 질의하던 방식에서 `CrewJoinRequest`를 한번만 쿼리하고 객체의 상태로 여러 조건 확인하는 방법으로 수정
  - `CrewJoinRequest`가 NotFound인 경우는 Service에서 조회하며 에러 반환
- 쿼리 확인, JPA 테스트를 위한 RepositoryTest 작성

### 트러블 슈팅

### 리뷰어에게 하고 싶은 말을 적어주세요
- Validator 로직에 Null들이 많이 보이기도하고 그런데 기능 개발 끝내고 리팩토링할때 생각해봐요~
- 계속 수정되고 조회되다보니 엔티티로 유지하되 연관은 걸지 않았습니다.
- @hughesgoon 작업하고 있다고 하신게 있었던 것 같아 conflict가 조금 걱정되네요 ㅠ 
### 확인하기

- [x] : 코드에 에러가 없는지 확인했나요?
- [x] : PR에 설명을 기재했나요?
- [x] : PR 태그를 붙였나요?
- [x] : 불필요한 로그나 `System.out`을 제거했나요?