### PR TITLE
[Fix/fetch-pace-categories] - 페이스 N개를 한번에 조회할때 에러 발생

### DIFF
--- a/src/main/java/com/run_us/server/domains/running/run/repository/RunRepository.java
+++ b/src/main/java/com/run_us/server/domains/running/run/repository/RunRepository.java
@@ -21,9 +21,8 @@ public interface RunRepository extends JpaRepository<Run, Integer> {
       "SELECT new com.run_us.server.domains.running.run.service.model.GetRunPreviewResponse"
           + "(u.profile.nickname, u.profile.imgUrl, r.preview) "
           + "FROM Run r "
-          + "join r.paceCategories "
           + "left join User u on r.hostId = u.id "
-          + "WHERE r.id = :runId")
+          + "WHERE r.id = :runId AND r.preview IS NOT NULL")
   GetRunPreviewResponse findByRunId(Integer runId);
 
 

--- a/src/main/java/com/run_us/server/domains/running/run/service/RunQueryService.java
+++ b/src/main/java/com/run_us/server/domains/running/run/service/RunQueryService.java
@@ -46,7 +46,10 @@ public class RunQueryService {
   }
 
   public GetRunPreviewResponse getRunPreviewById(Integer runId) {
-    return runRepository.findByRunId(runId);
+    Run run = findByRunId(runId);
+    GetRunPreviewResponse response = runRepository.findByRunId(runId);
+    response.setRunPaces(List.copyOf(run.getPaceCategories()));
+    return response;
   }
 
   // 2가지 쿼리 발생 : 1. 세션 정보 2. 페이스 태그 정보

--- a/src/main/java/com/run_us/server/domains/running/run/service/model/GetRunPreviewResponse.java
+++ b/src/main/java/com/run_us/server/domains/running/run/service/model/GetRunPreviewResponse.java
@@ -1,12 +1,20 @@
 package com.run_us.server.domains.running.run.service.model;
 
+import com.run_us.server.domains.running.run.domain.RunPace;
 import com.run_us.server.domains.running.run.domain.RunningPreview;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
 
 @Getter
+@AllArgsConstructor
 public class GetRunPreviewResponse {
   private final String hostName;
   private final String hostImgUrl;
+  @Setter
+  private List<RunPace> runPaces;
   private final RunningPreview preview;
 
   public GetRunPreviewResponse(String hostName, String hostImgUrl, RunningPreview preview) {


### PR DESCRIPTION
### 연관된 이슈를 적어주세요 📌
#73 

### 작업한 내용을 설명해주세요 ✔️
- 카테고리 정보는 별도의 쿼리에서 가져와서 설정하도록 수정.

### 트러블 슈팅
### 리뷰어에게 하고 싶은 말을 적어주세요
- jpql말고 native 쿼리 날리고 애플리케이션에서 조립하는 식으로 개선하면 쿼리는 1번으로 끝낼 수 있을 것 같습니당.
### 확인하기

- [x] : 코드에 에러가 없는지 확인했나요?
- [x] : PR에 설명을 기재했나요?
- [x] : PR 태그를 붙였나요?
- [x] : 불필요한 로그나 `System.out`을 제거했나요?