### PR TITLE
[Run/open-live-session] - 실시간 대기방 생성 API 개발

### DIFF
--- a/src/main/java/com/run_us/server/domains/running/common/RedisPassCodeRegistry.java
+++ b/src/main/java/com/run_us/server/domains/running/common/RedisPassCodeRegistry.java
@@ -18,7 +18,9 @@ public class RedisPassCodeRegistry implements PassCodeRegistry{
   public String generateAndGetPassCode(String runId) {
     String passCode;
     int retries = 0;
-
+    if(getRunIdByPassCode(runId).isPresent()) {
+      throw RunningException.of(RunningErrorCode.LIVE_RUNNING_ALREADY_CREATED);
+    }
     // 최대 재시도 횟수를 넘어가면 예외를 발생시킨다.
     // 초당 방 생성 요청 62개이상, 활성화된 입장코드가 68만개 이상일때
     // 10번 재시도 실패확률이 1%이상으로 예상되며 이때 예외를 발생시킨다.

--- a/src/main/java/com/run_us/server/domains/running/common/RunningConst.java
+++ b/src/main/java/com/run_us/server/domains/running/common/RunningConst.java
@@ -1,4 +1,4 @@
-package com.run_us.server.domains.running.live.service.model;
+package com.run_us.server.domains.running.common;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -7,6 +7,8 @@ import lombok.NoArgsConstructor;
 public final class RunningConst {
   public static final long UPDATE_INTERVAL = 1000; // 전체 참가자의 위치 업데이트 주기(1초)
   public static final double SIGNIFICANT_DISTANCE = 4; // 즉시 업데이트 중요 이벤트 기준(N미터 이상 이동시)
+  public static final int MAX_LIVE_SESSION_CREATION_TIME = 10; // 라이브세션 생성 최대 대기 시간(10분 까지)
+  public static final int LIVE_SESSION_ALLOW_ALL_TIME = 5; // 방장 외 라이브세션 생성 가능 시간 (5분 이후)
 
   public static final String RUNNING_PREFIX = "running:";
   public static final String STATUS_SUFFIX = ":status";

--- a/src/main/java/com/run_us/server/domains/running/common/RunningErrorCode.java
+++ b/src/main/java/com/run_us/server/domains/running/common/RunningErrorCode.java
@@ -26,7 +26,11 @@ public enum RunningErrorCode implements CustomResponseCode {
   RUNNING_SESSION_NOT_MODIFIABLE(
       "REH4006", "Running Session Not Modifiable", "Running Session Not Modifiable", HttpStatus.BAD_REQUEST),
   RUNNING_NOT_JOINABLE(
-      "REH4007", "Running Not Joinable", "Running Not Joinable", HttpStatus.BAD_REQUEST),;
+      "REH4007", "Running Not Joinable", "Running Not Joinable", HttpStatus.BAD_REQUEST),
+  LIVE_RUNNING_ALREADY_CREATED(
+      "REH4008", "Live Running Already Created", "Live Running Already Created", HttpStatus.BAD_REQUEST),
+  LIVE_RUNNING_CREATION_TIME_OVER(
+      "REH4009", "Live Running Creation Time Over", "Live Running Creation Time Over", HttpStatus.BAD_REQUEST),;
 
   private final String code;
   private final String clientMessage;

--- a/src/main/java/com/run_us/server/domains/running/live/controller/LiveRunningController.java
+++ b/src/main/java/com/run_us/server/domains/running/live/controller/LiveRunningController.java
@@ -1,0 +1,30 @@
+package com.run_us.server.domains.running.live.controller;
+
+import com.run_us.server.domains.running.live.service.model.LiveRunningCreateResponse;
+import com.run_us.server.domains.running.live.service.usecase.CreateLiveRunningUseCase;
+import com.run_us.server.global.common.SuccessResponse;
+import com.run_us.server.global.security.annotation.CurrentUser;
+import com.run_us.server.global.security.principal.UserPrincipal;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Controller
+@RequestMapping("/runnings/live")
+@RequiredArgsConstructor
+public class LiveRunningController {
+
+  private final CreateLiveRunningUseCase createLiveRunningUseCase;
+
+  @PostMapping()
+  public ResponseEntity<SuccessResponse<LiveRunningCreateResponse>> createLiveRunning(
+      @RequestParam("runPublicId") String runPublicId,
+      @CurrentUser UserPrincipal userPrincipal) {
+    SuccessResponse<LiveRunningCreateResponse> response =
+        createLiveRunningUseCase.createLiveRunning(runPublicId, userPrincipal.getInternalId());
+    return ResponseEntity.ok(response);
+  }
+}

--- a/src/main/java/com/run_us/server/domains/running/live/controller/RunningSocketController.java
+++ b/src/main/java/com/run_us/server/domains/running/live/controller/RunningSocketController.java
@@ -6,7 +6,7 @@ import com.run_us.server.domains.running.live.controller.model.RunningSocketRequ
 import com.run_us.server.domains.running.live.controller.model.RunningSocketResponse;
 import com.run_us.server.domains.running.live.controller.model.RunningSocketResponseCode;
 import com.run_us.server.domains.running.live.service.RunningLiveService;
-import com.run_us.server.domains.running.live.service.model.RunningConst;
+import com.run_us.server.domains.running.common.RunningConst;
 import com.run_us.server.global.common.SuccessResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/run_us/server/domains/running/live/controller/model/SubscriptionTopic.java
+++ b/src/main/java/com/run_us/server/domains/running/live/controller/model/SubscriptionTopic.java
@@ -1,6 +1,6 @@
 package com.run_us.server.domains.running.live.controller.model;
 
-import static com.run_us.server.domains.running.live.service.model.RunningConst.RUNNING_WS_SUBSCRIBE_PATH;
+import static com.run_us.server.domains.running.common.RunningConst.RUNNING_WS_SUBSCRIBE_PATH;
 import static com.run_us.server.global.common.SocketConst.USER_WS_SUBSCRIBE_PATH;
 
 import lombok.Getter;

--- a/src/main/java/com/run_us/server/domains/running/live/repository/RunningRedisRepository.java
+++ b/src/main/java/com/run_us/server/domains/running/live/repository/RunningRedisRepository.java
@@ -6,7 +6,7 @@ import static com.run_us.server.domains.running.live.service.util.RunningKeyUtil
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.run_us.server.domains.running.live.service.model.LocationData;
 import com.run_us.server.domains.running.live.service.model.ParticipantStatus;
-import com.run_us.server.domains.running.live.service.model.RunningConst;
+import com.run_us.server.domains.running.common.RunningConst;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;

--- a/src/main/java/com/run_us/server/domains/running/live/service/RunningLiveService.java
+++ b/src/main/java/com/run_us/server/domains/running/live/service/RunningLiveService.java
@@ -1,6 +1,6 @@
 package com.run_us.server.domains.running.live.service;
 
-import static com.run_us.server.domains.running.live.service.model.RunningConst.RUNNING_PREFIX;
+import static com.run_us.server.domains.running.common.RunningConst.RUNNING_PREFIX;
 import static com.run_us.server.domains.running.live.service.util.RunningKeyUtil.createLiveKey;
 
 import com.run_us.server.domains.running.live.controller.model.RunningSocketResponse;
@@ -9,7 +9,7 @@ import com.run_us.server.domains.running.live.repository.RunningRedisRepository;
 import com.run_us.server.domains.running.live.repository.UpdateLocationRepository;
 import com.run_us.server.domains.running.live.service.model.LocationData;
 import com.run_us.server.domains.running.live.service.model.ParticipantStatus;
-import com.run_us.server.domains.running.live.service.model.RunningConst;
+import com.run_us.server.domains.running.common.RunningConst;
 import com.run_us.server.domains.running.run.domain.Run;
 import com.run_us.server.domains.running.run.service.ParticipantService;
 import com.run_us.server.domains.running.run.service.RunCommandService;

--- a/src/main/java/com/run_us/server/domains/running/live/service/model/LiveRunningCreateResponse.java
+++ b/src/main/java/com/run_us/server/domains/running/live/service/model/LiveRunningCreateResponse.java
@@ -1,18 +1,23 @@
 package com.run_us.server.domains.running.live.service.model;
 
 import com.run_us.server.domains.running.run.domain.Run;
+import com.run_us.server.domains.running.run.service.model.ParticipantInfo;
 import lombok.Getter;
+
+import java.util.List;
 
 @Getter
 public class LiveRunningCreateResponse {
   private final String runPublicId;
   private final String passcode;
+  private final List<ParticipantInfo> participantInfos;
 
-  public LiveRunningCreateResponse(String runPublicId, String passcode) {
+  public LiveRunningCreateResponse(String runPublicId, String passcode, List<ParticipantInfo> participantInfos) {
     this.runPublicId = runPublicId;
     this.passcode = passcode;
+    this.participantInfos = participantInfos;
   }
-  public static LiveRunningCreateResponse from (Run run, String passcode) {
-    return new LiveRunningCreateResponse(run.getPublicId(), passcode);
+  public static LiveRunningCreateResponse from (Run run, String passcode, List<ParticipantInfo> participantInfos) {
+    return new LiveRunningCreateResponse(run.getPublicId(), passcode, participantInfos);
   }
 }

--- a/src/main/java/com/run_us/server/domains/running/live/service/model/LiveRunningCreateResponse.java
+++ b/src/main/java/com/run_us/server/domains/running/live/service/model/LiveRunningCreateResponse.java
@@ -1,0 +1,18 @@
+package com.run_us.server.domains.running.live.service.model;
+
+import com.run_us.server.domains.running.run.domain.Run;
+import lombok.Getter;
+
+@Getter
+public class LiveRunningCreateResponse {
+  private final String runPublicId;
+  private final String passcode;
+
+  public LiveRunningCreateResponse(String runPublicId, String passcode) {
+    this.runPublicId = runPublicId;
+    this.passcode = passcode;
+  }
+  public static LiveRunningCreateResponse from (Run run, String passcode) {
+    return new LiveRunningCreateResponse(run.getPublicId(), passcode);
+  }
+}

--- a/src/main/java/com/run_us/server/domains/running/live/service/usecase/CreateLiveRunningUseCase.java
+++ b/src/main/java/com/run_us/server/domains/running/live/service/usecase/CreateLiveRunningUseCase.java
@@ -1,0 +1,8 @@
+package com.run_us.server.domains.running.live.service.usecase;
+
+import com.run_us.server.domains.running.live.service.model.LiveRunningCreateResponse;
+import com.run_us.server.global.common.SuccessResponse;
+
+public interface CreateLiveRunningUseCase {
+  SuccessResponse<LiveRunningCreateResponse> createLiveRunning(String runPublicId, Integer userId);
+}

--- a/src/main/java/com/run_us/server/domains/running/live/service/usecase/CreateLiveRunningUseCaseImpl.java
+++ b/src/main/java/com/run_us/server/domains/running/live/service/usecase/CreateLiveRunningUseCaseImpl.java
@@ -7,10 +7,13 @@ import com.run_us.server.domains.running.run.domain.Run;
 import com.run_us.server.domains.running.run.service.ParticipantService;
 import com.run_us.server.domains.running.run.service.RunQueryService;
 import com.run_us.server.domains.running.run.service.RunValidator;
+import com.run_us.server.domains.running.run.service.model.ParticipantInfo;
 import com.run_us.server.global.common.SuccessResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -29,6 +32,9 @@ public class CreateLiveRunningUseCaseImpl implements CreateLiveRunningUseCase {
     participantService.joinLiveRunning(userId, selectedRun);
     String passcode = passCodeRegistry.generateAndGetPassCode(runPublicId);
     selectedRun.openLiveSession(userId);
-    return SuccessResponse.of(RunningHttpResponseCode.LIVE_ROOM_CREATED, LiveRunningCreateResponse.from(selectedRun, passcode));
+    List<ParticipantInfo> participantInfos = participantService.getParticipants(selectedRun);
+    return SuccessResponse.of(RunningHttpResponseCode.LIVE_ROOM_CREATED, LiveRunningCreateResponse.from(selectedRun, passcode, participantInfos));
   }
+
+
 }

--- a/src/main/java/com/run_us/server/domains/running/live/service/usecase/CreateLiveRunningUseCaseImpl.java
+++ b/src/main/java/com/run_us/server/domains/running/live/service/usecase/CreateLiveRunningUseCaseImpl.java
@@ -1,0 +1,34 @@
+package com.run_us.server.domains.running.live.service.usecase;
+
+import com.run_us.server.domains.running.common.PassCodeRegistry;
+import com.run_us.server.domains.running.live.service.model.LiveRunningCreateResponse;
+import com.run_us.server.domains.running.run.controller.model.RunningHttpResponseCode;
+import com.run_us.server.domains.running.run.domain.Run;
+import com.run_us.server.domains.running.run.service.ParticipantService;
+import com.run_us.server.domains.running.run.service.RunQueryService;
+import com.run_us.server.domains.running.run.service.RunValidator;
+import com.run_us.server.global.common.SuccessResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CreateLiveRunningUseCaseImpl implements CreateLiveRunningUseCase {
+
+  private final RunQueryService runQueryService;
+  private final RunValidator runValidator;
+  private final ParticipantService participantService;
+  private final PassCodeRegistry passCodeRegistry;
+
+  @Override
+  @Transactional
+  public SuccessResponse<LiveRunningCreateResponse> createLiveRunning(String runPublicId, Integer userId) {
+    Run selectedRun = runQueryService.findByRunPublicId(runPublicId);
+    runValidator.validateCurrentUserCanStartRun(userId, selectedRun);
+    participantService.joinLiveRunning(userId, selectedRun);
+    String passcode = passCodeRegistry.generateAndGetPassCode(runPublicId);
+    selectedRun.openLiveSession(userId);
+    return SuccessResponse.of(RunningHttpResponseCode.LIVE_ROOM_CREATED, LiveRunningCreateResponse.from(selectedRun, passcode));
+  }
+}

--- a/src/main/java/com/run_us/server/domains/running/live/service/util/RunningKeyUtil.java
+++ b/src/main/java/com/run_us/server/domains/running/live/service/util/RunningKeyUtil.java
@@ -1,6 +1,6 @@
 package com.run_us.server.domains.running.live.service.util;
 
-import com.run_us.server.domains.running.live.service.model.RunningConst;
+import com.run_us.server.domains.running.common.RunningConst;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 

--- a/src/main/java/com/run_us/server/domains/running/run/domain/Run.java
+++ b/src/main/java/com/run_us/server/domains/running/run/domain/Run.java
@@ -12,6 +12,7 @@ import lombok.NoArgsConstructor;
 import java.time.ZonedDateTime;
 import java.util.List;
 
+import static com.run_us.server.domains.running.common.RunningConst.LIVE_SESSION_ALLOW_ALL_TIME;
 import static com.run_us.server.domains.running.common.RunningConst.MAX_LIVE_SESSION_CREATION_TIME;
 
 @Entity
@@ -105,6 +106,14 @@ public class Run extends CreationTimeAudit {
   public void exposeToCrew(Integer crewPublicId) {
     validateRunModifiable();
     this.crewId = crewPublicId;
+  }
+
+  public boolean isLiveSessionCreatableByHost() {
+    return ZonedDateTime.now().isAfter(this.preview.getBeginTime().minusMinutes(10));
+  }
+
+  public boolean isLiveSessionCreatableByAnyone() {
+    return ZonedDateTime.now().isAfter(this.getPreview().getBeginTime().plusMinutes(LIVE_SESSION_ALLOW_ALL_TIME));
   }
 
   private void validateRunModifiable() {

--- a/src/main/java/com/run_us/server/domains/running/run/domain/Run.java
+++ b/src/main/java/com/run_us/server/domains/running/run/domain/Run.java
@@ -9,7 +9,10 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.ZonedDateTime;
 import java.util.List;
+
+import static com.run_us.server.domains.running.common.RunningConst.MAX_LIVE_SESSION_CREATION_TIME;
 
 @Entity
 @Table(name = "run")
@@ -22,7 +25,11 @@ public class Run extends CreationTimeAudit {
   @Column(name = "run_id")
   private Integer id;
 
+  @Column(name = "run_host_id")
   private Integer hostId;
+
+  @Column(name = "session_host_id")
+  private Integer sessionHostId;
 
   private String publicId;
 
@@ -41,11 +48,13 @@ public class Run extends CreationTimeAudit {
   // 생성
   public Run(Integer hostId) {
     this.hostId = hostId;
+    this.sessionHostId = hostId;
     this.status = RunStatus.WAITING;
   }
 
   public Run (Integer hostId, Integer crewId) {
     this.hostId = hostId;
+    this.sessionHostId = hostId;
     this.crewId = crewId;
   }
 
@@ -75,6 +84,18 @@ public class Run extends CreationTimeAudit {
 
   public boolean isHost(int userId) {
     return this.hostId.equals(userId);
+  }
+
+  public boolean isCreationTimeOver() {
+    return this.preview.getBeginTime()
+        .plusMinutes(MAX_LIVE_SESSION_CREATION_TIME)
+        .isBefore(ZonedDateTime.now());
+  }
+
+  public void openLiveSession(Integer userId) {
+    validateRunModifiable();
+    this.sessionHostId = userId;
+    this.status = RunStatus.RUNNING;
   }
 
   public void modifyPaceInfo(List<RunPace> runPaces) {

--- a/src/main/java/com/run_us/server/domains/running/run/repository/ParticipantRepository.java
+++ b/src/main/java/com/run_us/server/domains/running/run/repository/ParticipantRepository.java
@@ -21,4 +21,6 @@ public interface ParticipantRepository extends JpaRepository<Participant, Long> 
           + "join User u on p.userId = u.id "
           + "WHERE p.run.id = :runId")
   List<ParticipantInfo> findByRunId(Integer runId);
+
+  boolean existsByUserIdAndRunId(Integer userId, Integer runId);
 }

--- a/src/main/java/com/run_us/server/domains/running/run/service/ParticipantService.java
+++ b/src/main/java/com/run_us/server/domains/running/run/service/ParticipantService.java
@@ -46,4 +46,8 @@ public class ParticipantService {
   public List<ParticipantInfo> getParticipants(Run run) {
     return participantRepository.findByRunId(run.getId());
   }
+
+  public boolean isRegistered(Integer userId, Run selectedRun) {
+    return participantRepository.existsByUserIdAndRunId(userId, selectedRun.getId());
+  }
 }

--- a/src/main/java/com/run_us/server/domains/running/run/service/RunValidator.java
+++ b/src/main/java/com/run_us/server/domains/running/run/service/RunValidator.java
@@ -8,10 +8,6 @@ import com.run_us.server.domains.running.run.service.model.RunCreateDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
-import java.time.ZonedDateTime;
-
-import static com.run_us.server.domains.running.common.RunningConst.LIVE_SESSION_ALLOW_ALL_TIME;
-
 @Component
 @RequiredArgsConstructor
 public final class RunValidator {

--- a/src/main/java/com/run_us/server/domains/running/run/service/RunValidator.java
+++ b/src/main/java/com/run_us/server/domains/running/run/service/RunValidator.java
@@ -53,15 +53,12 @@ public final class RunValidator {
     if(!run.isJoinable()) {
       throw RunningException.of(RunningErrorCode.RUNNING_NOT_JOINABLE);
     }
+
     if(!participantService.isRegistered(userId, run)) {
       throw RunningException.of(RunningErrorCode.USER_NOT_JOINED);
     }
-    if(!isHostWaitingTimeOver(run)) {
+    if(!run.isLiveSessionCreatableByAnyone() && run.isLiveSessionCreatableByHost()) {
       validateIsRunOwner(userId, run);
     }
-  }
-
-  private boolean isHostWaitingTimeOver(Run run) {
-    return run.getPreview().getBeginTime().plusMinutes(LIVE_SESSION_ALLOW_ALL_TIME).isBefore(ZonedDateTime.now());
   }
 }

--- a/src/test/java/com/run_us/server/domains/crew/domain/CrewJoinRequestRepositoryTest.java
+++ b/src/test/java/com/run_us/server/domains/crew/domain/CrewJoinRequestRepositoryTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
 
 import java.time.ZonedDateTime;
 
@@ -18,6 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @DataJpaTest
+@ActiveProfiles("test")
 public class CrewJoinRequestRepositoryTest {
 
   @Autowired

--- a/src/test/java/com/run_us/server/domains/crew/service/CrewValidatorTest.java
+++ b/src/test/java/com/run_us/server/domains/crew/service/CrewValidatorTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
 
 import java.time.ZonedDateTime;
 import java.util.Optional;
@@ -20,6 +21,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class CrewValidatorTest {
 
   @MockBean

--- a/src/test/java/com/run_us/server/domains/running/RunTest.java
+++ b/src/test/java/com/run_us/server/domains/running/RunTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.params.provider.EnumSource;
 
 import java.time.ZonedDateTime;
 
+import static com.run_us.server.domains.running.common.RunningConst.MAX_LIVE_SESSION_CREATION_TIME;
 import static org.junit.jupiter.api.Assertions.*;
 
 class RunTest {
@@ -61,5 +62,32 @@ class RunTest {
     Run run = RunFixtures.createRun();
     run.changeStatus(runStatus);
     assertFalse(run.isDeletable());
+  }
+
+  @DisplayName("라이브 세션 생성 시 생성자의 id로 세션 호스트 수정")
+  @Test
+  void test_change_live_session_host() {
+    Run run = RunFixtures.createRun();
+    Integer liveSessionCreatorId = 2;
+
+    //when
+    run.openLiveSession(liveSessionCreatorId);
+
+    //then
+    assertEquals(liveSessionCreatorId, run.getSessionHostId());
+  }
+
+  @DisplayName("세션 시작 시간 10분 초과하면 실시간 러닝을 시작할 수 없음")
+  @Test
+  void test_should_return_true_when_current_time_is_behind_beginning_time(){
+    Run run = RunFixtures.createRun();
+    ZonedDateTime beginsAt = ZonedDateTime.now().minusMinutes(MAX_LIVE_SESSION_CREATION_TIME + 1);
+    run.modifySessionInfo(RunningPreview.builder().beginTime(beginsAt).build());
+
+    //when
+    boolean isBeginningTimePassed = run.isCreationTimeOver();
+
+    //then
+    assertTrue(isBeginningTimePassed);
   }
 }

--- a/src/test/java/com/run_us/server/domains/running/RunTest.java
+++ b/src/test/java/com/run_us/server/domains/running/RunTest.java
@@ -90,4 +90,18 @@ class RunTest {
     //then
     assertTrue(isBeginningTimePassed);
   }
+
+  @DisplayName("세션 시작 시간 10분 전에는 세션글 작성자만 시작할 수 있음.")
+  @Test
+  void test_should_return_false_when_participant_creates_before_10_min() {
+    Run run = RunFixtures.createRun();
+    ZonedDateTime beginsIn10Min = ZonedDateTime.now().plusMinutes(MAX_LIVE_SESSION_CREATION_TIME);
+    run.modifySessionInfo(RunningPreview.builder().beginTime(beginsIn10Min).build());
+
+    //when
+    boolean isLiveSessionCreatableByAnyone = run.isLiveSessionCreatableByAnyone();
+    boolean isLiveSessionCreatableByHost = run.isLiveSessionCreatableByHost();
+    assertFalse(isLiveSessionCreatableByAnyone);
+    assertTrue(isLiveSessionCreatableByHost);
+  }
 }

--- a/src/test/java/com/run_us/server/domains/running/controller/model/enums/SubscriptionTopicTest.java
+++ b/src/test/java/com/run_us/server/domains/running/controller/model/enums/SubscriptionTopicTest.java
@@ -1,12 +1,9 @@
 package com.run_us.server.domains.running.controller.model.enums;
 
-import static com.run_us.server.domains.running.live.service.model.RunningConst.RUNNING_WS_SUBSCRIBE_PATH;
-import static com.run_us.server.global.common.SocketConst.USER_WS_SUBSCRIBE_PATH;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.run_us.server.domains.running.live.controller.model.SubscriptionTopic;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 @DisplayName("SubscriptionTopic 클래스의")


### PR DESCRIPTION
### 연관된 이슈를 적어주세요 📌

### 작업한 내용을 설명해주세요 ✔️

- 생성한 세션에 대해 실시간 달리기 방을 만드는 API입니다.

- 요구사항은 다음과 같습니다.

  1. 시작시간 10분 전에는 세션글 작성자만 대기방을 열 수 있음.
  2. 시작시간 이후 5분까지는 세션글 작성자가 대기방을 열 수 있음.
  3. 시작시간 5분 이후부터는 참가자가 아무나 열 수 있음.
  4. 시작시간 10분 이후에는 세션이 취소된 상태로 간주하고 아무도 열 수 없음.

- 구현 사항
  - validator에 대기방 생성에 대한 검증 로직 추가
  - 대기방을 생성한 사람은 id를 저장. >> 추후 통계 작업 시 대기방의 방장의 기록을 사용
  - 방장에게 passcode와 run_public_id 반환


### 트러블 슈팅
- #76 `@CurrentUser` 사용에서 유저 아이디를 받지 못하고 익명유저로 id가 넘어가고 있습니다.
ThreadLocal 한 객체인 Authentication을 jwt filter에서 세팅하는 로직이 없어서 그런 것 같습니다. 
### 리뷰어에게 하고 싶은 말을 적어주세요
- 노션의 비즈니스 요구사항을 열심히 보고 개발했는데, 혹시 잘못된 로직이 있다면 꼭 피드백 부탁드립니다!
### 확인하기

- [x] : 코드에 에러가 없는지 확인했나요?
- [x] : PR에 설명을 기재했나요?
- [x] : PR 태그를 붙였나요?
- [x] : 불필요한 로그나 `System.out`을 제거했나요?