### PR TITLE
[Fix/redis-connection] 레디스 커넥션 문제 해결

### DIFF
--- a/.github/workflows/develop-ci.yml
+++ b/.github/workflows/develop-ci.yml
@@ -5,7 +5,7 @@ on:
       - main
       - 'feature/**'
   pull_request:
-    types: [ opened, reopened, edited ]
+    types: [ opened, reopened, edited, synchronize ]
 jobs:
   build:
     name: Build and analyze

--- a/src/main/java/com/run_us/server/RunUsApplication.java
+++ b/src/main/java/com/run_us/server/RunUsApplication.java
@@ -2,7 +2,9 @@ package com.run_us.server;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class RunUsApplication {
 

--- a/src/main/java/com/run_us/server/domains/crew/domain/Crew.java
+++ b/src/main/java/com/run_us/server/domains/crew/domain/Crew.java
@@ -23,6 +23,7 @@ import java.util.List;
 public class Crew extends DateAudit {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "crew_id")
     private Integer id;
 
     @Column(name = "public_id", nullable = false, columnDefinition = "CHAR(13)")

--- a/src/main/java/com/run_us/server/domains/running/live/controller/RunningSocketController.java
+++ b/src/main/java/com/run_us/server/domains/running/live/controller/RunningSocketController.java
@@ -7,6 +7,7 @@ import com.run_us.server.domains.running.live.controller.model.RunningSocketResp
 import com.run_us.server.domains.running.live.controller.model.RunningSocketResponseCode;
 import com.run_us.server.domains.running.live.service.RunningLiveService;
 import com.run_us.server.domains.running.common.RunningConst;
+import com.run_us.server.domains.running.live.service.RunningWebsocketService;
 import com.run_us.server.global.common.SuccessResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -22,7 +23,7 @@ public class RunningSocketController {
 
   private final SimpMessagingTemplate simpMessagingTemplate;
   private final RunningLiveService runningLiveService;
-
+  private final RunningWebsocketService runningWebsocketService;
   /**
    * 러닝 시작
    * @param userId 사용자 (고유번호 세션에서 추출)
@@ -32,7 +33,7 @@ public class RunningSocketController {
   public void startRunning(@UserId String userId, RunningSocketRequest.StartRunning requestDto) {
     log.info("action=start_running user_id={} running_id={}", userId, requestDto.getRunningPublicId());
     SuccessResponse<RunningSocketResponse.StartRunning> response =
-        runningLiveService.startRunning(requestDto.getRunningPublicId(), userId, requestDto.getCount());
+        runningWebsocketService.startRunningSession(requestDto.getRunningPublicId(), requestDto.getCount());
     simpMessagingTemplate.convertAndSend(
         RunningConst.RUNNING_WS_SEND_PREFIX + requestDto.getRunningPublicId(), response);
   }
@@ -45,13 +46,12 @@ public class RunningSocketController {
   @MessageMapping("/users/runnings/location")
   public void updateLocation(@UserId String userId,  RunningSocketRequest.LocationUpdate requestDto) {
     log.info("action=update_running user_id={} running_id={}", userId, requestDto.getRunningPublicId());
-    SuccessResponse<RunningSocketResponse.LocationUpdate> response = runningLiveService.updateLocation(
+    runningLiveService.updateLocation(
         requestDto.getRunningPublicId(),
         userId,
         requestDto.getLatitude(),
         requestDto.getLongitude(),
         requestDto.getCount());
-    simpMessagingTemplate.convertAndSend(RunningConst.RUNNING_WS_SEND_PREFIX + requestDto.getRunningPublicId(), response);
   }
 
   /***

--- a/src/main/java/com/run_us/server/domains/running/live/service/RunningWebsocketService.java
+++ b/src/main/java/com/run_us/server/domains/running/live/service/RunningWebsocketService.java
@@ -1,0 +1,87 @@
+package com.run_us.server.domains.running.live.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.run_us.server.domains.running.common.RunningConst;
+import com.run_us.server.domains.running.live.controller.model.RunningSocketResponse;
+import com.run_us.server.domains.running.live.controller.model.RunningSocketResponseCode;
+import com.run_us.server.domains.running.live.repository.RunningRedisRepository;
+import com.run_us.server.domains.running.live.service.model.LocationData;
+
+import com.run_us.server.global.common.SuccessResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RunningWebsocketService {
+
+  private final RunningLiveService runningLiveService;
+  private final RunningRedisRepository runningRedisRepository;
+  private final SimpMessagingTemplate simpMessagingTemplate;
+  private final ObjectMapper objectMapper;
+  private final Map<String, ScheduledExecutorService> sessionSchedulers = new ConcurrentHashMap<>();
+
+  /***
+   * 러닝세션 시작: 전체 참가자 상태를 RUN으로 변경하고, 위치 업데이트 스케줄러 시작
+   * @param runningId 러닝세션 외부 노출용 ID
+   */
+  public SuccessResponse<RunningSocketResponse.StartRunning> startRunningSession(String runningId, long count) {
+    ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+    scheduler.scheduleAtFixedRate(
+        new BroadcastPositionsTask(runningId),
+        0,
+        RunningConst.UPDATE_INTERVAL,
+        TimeUnit.MILLISECONDS);
+    sessionSchedulers.put(runningId, scheduler);
+    return SuccessResponse.of(
+        RunningSocketResponseCode.START_RUNNING,
+        new RunningSocketResponse.StartRunning(runningId, count));
+  }
+
+  /***
+   * 러닝세션 종료: 전체 참가자 상태를 END로 변경하고, 위치 업데이트 스케줄러 종료
+   * @param runningId 러닝세션 외부 노출용 ID
+   */
+  public void finishRunningSession(String runningId) {
+    ScheduledExecutorService scheduler = sessionSchedulers.remove(runningId);
+    if (scheduler != null) {
+      scheduler.shutdown();
+    }
+
+    Set<String> participants = runningRedisRepository.getSessionParticipants(runningId);
+    for (String userId : participants) {
+      runningLiveService.endRunning(runningId, userId);
+    }
+  }
+
+  private class BroadcastPositionsTask implements Runnable {
+
+    private String runningId;
+
+    public BroadcastPositionsTask(String runningId) {
+      this.runningId = runningId;
+    }
+
+    @Override
+    public void run() {
+      Map<String, LocationData.RunnerPos> participantsLocations = runningRedisRepository.getAllParticipantsLocations(runningId);
+      try {
+        String message = objectMapper.writeValueAsString(participantsLocations);
+        simpMessagingTemplate.convertAndSend(RunningConst.RUNNING_WS_SEND_PREFIX + runningId, message);
+      } catch (JsonProcessingException e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+}

--- a/src/main/java/com/run_us/server/global/config/RedisConfig.java
+++ b/src/main/java/com/run_us/server/global/config/RedisConfig.java
@@ -63,4 +63,19 @@ public class RedisConfig {
         redisTemplate.setValueSerializer(new StringRedisSerializer());
         return redisTemplate;
     }
+
+    @Bean
+    public RedisTemplate<String, Serializable> serializableRedisTemplate() {
+        RedisTemplate<String, Serializable> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new GenericToStringSerializer<>(String.class));
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        return redisTemplate;
+    }
+
+    @Bean
+    public DefaultRedisScript<Boolean> updateLocationScript() throws IOException {
+        ScriptSource source = new ResourceScriptSource(new ClassPathResource("META-INF/scripts/update_location.lua"));
+        return new DefaultRedisScript<>(source.getScriptAsString(), Boolean.class);
+    }
 }

--- a/src/main/java/com/run_us/server/global/config/RedisConfig.java
+++ b/src/main/java/com/run_us/server/global/config/RedisConfig.java
@@ -1,15 +1,29 @@
 package com.run_us.server.global.config;
 
+import io.lettuce.core.ClientOptions;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.data.redis.core.script.RedisScript;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.GenericToStringSerializer;
+import org.springframework.data.redis.serializer.JdkSerializationRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
+import org.springframework.scripting.ScriptSource;
+import org.springframework.scripting.support.ResourceScriptSource;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.time.Duration;
 
 @Configuration
 @EnableRedisRepositories
@@ -22,12 +36,23 @@ public class RedisConfig {
     @Value("${spring.data.redis.port}")
     private int redisPort;
 
+    @Value("${spring.data.redis.password}")
+    private String redisPassword;
+
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
         RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration();
         redisStandaloneConfiguration.setHostName(redisHost);
         redisStandaloneConfiguration.setPort(redisPort);
-        return new LettuceConnectionFactory(redisStandaloneConfiguration);
+        redisStandaloneConfiguration.setPassword(redisPassword);
+        ClientOptions clientOptions = ClientOptions.builder()
+            .pingBeforeActivateConnection(true)
+            .autoReconnect(true)
+                .build();
+        LettuceClientConfiguration clientConfig = LettuceClientConfiguration.builder()
+            .clientOptions(clientOptions)
+            .build();
+      return new LettuceConnectionFactory(redisStandaloneConfiguration, clientConfig);
     }
 
     @Bean

--- a/src/main/resources/META-INF/scripts/update_location.lua
+++ b/src/main/resources/META-INF/scripts/update_location.lua
@@ -1,0 +1,24 @@
+-- Lua Script: Compare and Update Location if Count is Greater
+-- KEYS[1]: Redis key (location identifier)
+-- ARGV[1]: Latitude
+-- ARGV[2]: Longitude
+-- ARGV[3]: TTL (Time-to-Live in seconds)
+-- ARGV[4]: Count
+
+local current = redis.call('GET', KEYS[1])
+
+if current then
+    local currentData = cjson.decode(current)
+    if tonumber(ARGV[4]) <= currentData.count then
+        return false -- Do not update if the current count is greater or equal
+    end
+end
+
+local newData = cjson.encode({
+    latitude = tonumber(ARGV[1]),
+    longitude = tonumber(ARGV[2]),
+    count = tonumber(ARGV[4])
+})
+
+redis.call('SET', KEYS[1], newData, 'EX', ARGV[3])
+return true -- Successfully updated

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,11 @@
 server:
   port: 8080
-
+  tomcat:
+    threads:
+      max: 200
+    accept-count: 100
+    max-connections: 8912
+    max-keep-alive-requests: 200
 spring:
   config:
     import:
@@ -17,7 +22,6 @@ spring:
     properties:
       hibernate:
         dialect: ${JPA_DIALECT}
-        format_sql: true
     open-in-view: false
   jackson:
     property-naming-strategy: SNAKE_CASE

--- a/src/test/java/com/run_us/server/RunUsApplicationTests.java
+++ b/src/test/java/com/run_us/server/RunUsApplicationTests.java
@@ -1,9 +1,14 @@
 package com.run_us.server;
 
+import com.run_us.server.config.TestRedisConfiguration;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@Import({TestRedisConfiguration.class})
+@ActiveProfiles("test")
 class RunUsApplicationTests {
 
 	@Test

--- a/src/test/java/com/run_us/server/config/TestRedisConfiguration.java
+++ b/src/test/java/com/run_us/server/config/TestRedisConfiguration.java
@@ -5,12 +5,20 @@ import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Profile;
+import org.springframework.core.io.ClassPathResource;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.GenericToStringSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
+import org.springframework.scripting.ScriptSource;
+import org.springframework.scripting.support.ResourceScriptSource;
+
+import java.io.IOException;
+import java.io.Serializable;
 
 @TestConfiguration
 @Profile("test")
@@ -45,5 +53,20 @@ public class TestRedisConfiguration {
     redisTemplate.setKeySerializer(new StringRedisSerializer());
     redisTemplate.setValueSerializer(new StringRedisSerializer());
     return redisTemplate;
+  }
+
+  @Bean
+  public RedisTemplate<String, Serializable> serializableRedisTemplate() {
+    RedisTemplate<String, Serializable> redisTemplate = new RedisTemplate<>();
+    redisTemplate.setKeySerializer(new StringRedisSerializer());
+    redisTemplate.setValueSerializer(new GenericToStringSerializer<>(String.class));
+    redisTemplate.setConnectionFactory(redisConnectionFactory());
+    return redisTemplate;
+  }
+
+  @Bean
+  public DefaultRedisScript<Boolean> updateLocationScript() throws IOException {
+    ScriptSource source = new ResourceScriptSource(new ClassPathResource("META-INF/scripts/update_location.lua"));
+    return new DefaultRedisScript<>(source.getScriptAsString(), Boolean.class);
   }
 }

--- a/src/test/java/com/run_us/server/domains/crew/service/CrewValidatorTest.java
+++ b/src/test/java/com/run_us/server/domains/crew/service/CrewValidatorTest.java
@@ -6,28 +6,33 @@ import com.run_us.server.domains.crew.domain.CrewFixtures;
 import com.run_us.server.domains.crew.domain.CrewJoinRequest;
 import com.run_us.server.domains.crew.domain.enums.CrewJoinRequestStatus;
 import com.run_us.server.domains.crew.repository.CrewJoinRequestRepository;
+import com.run_us.server.domains.crew.repository.CrewRepository;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.context.ActiveProfiles;
 
 import java.time.ZonedDateTime;
 import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
-@SpringBootTest
 @ActiveProfiles("test")
+@ExtendWith(MockitoExtension.class)
 class CrewValidatorTest {
 
-  @MockBean
+  @Mock
+  private CrewRepository crewRepository;
+  @Mock
   private CrewJoinRequestRepository crewJoinRequestRepository;
 
-  @Autowired
+  @InjectMocks
   private CrewValidator crewValidator;
 
   @DisplayName("한달 이내에 제출한 가입신청이 아직 처리되지 않은 경우 에러 반환")
@@ -45,6 +50,7 @@ class CrewValidatorTest {
             .processedAt(null)
             .build())
     );
+    when(crewRepository.existsMembershipByCrewIdAndUserId(any(), any())).thenReturn(false);
     assertThrows(CrewException.class, () -> crewValidator.validateCanJoinCrew(userId, crew));
   }
 
@@ -63,6 +69,8 @@ class CrewValidatorTest {
             .processedAt(ZonedDateTime.now())
             .build())
     );
+    when(crewRepository.existsMembershipByCrewIdAndUserId(any(), any())).thenReturn(false);
+
     assertThrows(CrewException.class, () -> crewValidator.validateCanJoinCrew(userId, crew));
   }
 }


### PR DESCRIPTION
### 연관된 이슈를 적어주세요 📌
#77 

### 작업한 내용을 설명해주세요 ✔️

- 서버에서 NOAUTH 문제로 레디스 연결이 안되는 이슈가 발생했습니다. 
- pub-sub으로 모든 메세지를 바로 릴레이하던 로직에서 중앙 스케줄러가 push하는 방식으로 구현 변경
- 위치 업데이트의 원자성 + 레디스 요청 횟수를 줄이기 위해, 2번의 request로 처리하던 로직을 lua스크립트로 변경했습니다.

### 트러블 슈팅
- 부하테스트 시, 과도한 네트워크 IO로 lettuce가 죽어버리는 문제가 발생했습니다.
![Screenshot 2025-01-24 at 12 14 27 AM](https://github.com/user-attachments/assets/5665b8d4-1dec-4fc0-a11a-7fd1a5ba1579)

- 레디스 직렬화에러가 발생하여 새로운 RedisTemplate 객체를 빈으로 등록했습니다. 다만 RedisTemplate을 런타임에 2개 가지고있는 것이 염려되어 <String,String> 도 일괄적으로 처리할 수 있는지 확인해보고 개선하겠습니다.
### 리뷰어에게 하고 싶은 말을 적어주세요

### 확인하기

- [x] : 코드에 에러가 없는지 확인했나요?
- [x] : PR에 설명을 기재했나요?
- [x] : PR 태그를 붙였나요?
- [x] : 불필요한 로그나 `System.out`을 제거했나요?